### PR TITLE
feat #POP-45: 팝업 리스트 조회

### DIFF
--- a/src/main/java/com/example/popin/domain/popup/controller/PopupController.java
+++ b/src/main/java/com/example/popin/domain/popup/controller/PopupController.java
@@ -9,29 +9,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validator;
+import java.util.Set;
+
 @RestController
 @RequestMapping("/api/popups")
 @RequiredArgsConstructor
 public class PopupController {
 
     private final PopupService popupService;
+    private final Validator validator;
 
     // 팝업스토어 리스트 조회
     @GetMapping
-    public ResponseEntity<PopupListResponseDto> getPopupList(
-            @RequestParam(required = false) PopupStatus status,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size,
-            @RequestParam(defaultValue = "createdAt") String sortBy,
-            @RequestParam(defaultValue = "DESC") String sortDirection) {
-
-        PopupListRequestDto request = new PopupListRequestDto();
-        request.setStatus(status);
-        request.setPage(page);
-        request.setSize(size);
-        request.setSortBy(sortBy);
-        request.setSortDirection(sortDirection);
-
+    public ResponseEntity<PopupListResponseDto> getPopupList(@Valid PopupListRequestDto request) {
         PopupListResponseDto response = popupService.getPopupList(request);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/popin/domain/popup/controller/PopupController.java
+++ b/src/main/java/com/example/popin/domain/popup/controller/PopupController.java
@@ -1,0 +1,45 @@
+package com.example.popin.domain.popup.controller;
+
+import com.example.popin.domain.popup.dto.request.PopupListRequestDto;
+import com.example.popin.domain.popup.dto.response.PopupDetailResponseDto;
+import com.example.popin.domain.popup.dto.response.PopupListResponseDto;
+import com.example.popin.domain.popup.entity.PopupStatus;
+import com.example.popin.domain.popup.service.PopupService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/popups")
+@RequiredArgsConstructor
+public class PopupController {
+
+    private final PopupService popupService;
+
+    // 팝업스토어 리스트 조회
+    @GetMapping
+    public ResponseEntity<PopupListResponseDto> getPopupList(
+            @RequestParam(required = false) PopupStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "createdAt") String sortBy,
+            @RequestParam(defaultValue = "DESC") String sortDirection) {
+
+        PopupListRequestDto request = new PopupListRequestDto();
+        request.setStatus(status);
+        request.setPage(page);
+        request.setSize(size);
+        request.setSortBy(sortBy);
+        request.setSortDirection(sortDirection);
+
+        PopupListResponseDto response = popupService.getPopupList(request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 팜업스토어 상세 조회
+    @GetMapping("/{popupId}")
+    public ResponseEntity<PopupDetailResponseDto> getPopupDetail(@PathVariable Long popupId) {
+        PopupDetailResponseDto response = popupService.getPopupDetail(popupId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/popin/domain/popup/dto/request/PopupListRequestDto.java
+++ b/src/main/java/com/example/popin/domain/popup/dto/request/PopupListRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.popin.domain.popup.dto.request;
+
+import com.example.popin.domain.popup.entity.PopupStatus;
+import lombok.Data;
+
+@Data
+public class PopupListRequestDto {
+    private PopupStatus status;
+    private int page = 0;
+    private int size = 20;
+    private String sortBy = "createdAt";
+    private String sortDirection = "DESC";
+}

--- a/src/main/java/com/example/popin/domain/popup/dto/request/PopupListRequestDto.java
+++ b/src/main/java/com/example/popin/domain/popup/dto/request/PopupListRequestDto.java
@@ -3,10 +3,16 @@ package com.example.popin.domain.popup.dto.request;
 import com.example.popin.domain.popup.entity.PopupStatus;
 import lombok.Data;
 
+import javax.validation.constraints.Min;
+
 @Data
 public class PopupListRequestDto {
     private PopupStatus status;
+
+    @Min(0)
     private int page = 0;
+
+    @Min(1)
     private int size = 20;
     private String sortBy = "createdAt";
     private String sortDirection = "DESC";

--- a/src/main/java/com/example/popin/domain/popup/dto/response/PopupDetailResponseDto.java
+++ b/src/main/java/com/example/popin/domain/popup/dto/response/PopupDetailResponseDto.java
@@ -1,0 +1,38 @@
+package com.example.popin.domain.popup.dto.response;
+
+import com.example.popin.domain.popup.entity.PopupStatus;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class PopupDetailResponseDto {
+    private Long id;
+    private Long brandId;
+    private Long venueId;
+    private String title;
+    private String summary;
+    private String description;
+    private String period;
+    private PopupStatus status;
+    private String mainImageUrl;
+    private Boolean isFeatured;
+
+    private Boolean reservationAvailable;
+    private String reservationLink;
+    private Boolean waitlistAvailable;
+
+    private Integer entryFee;
+    private Boolean isFreeEntry;
+    private String feeDisplayText;
+
+    private String notice;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private List<PopupImageResponseDto> images;
+    private List<PopupHoursResponseDto> hours;
+}

--- a/src/main/java/com/example/popin/domain/popup/dto/response/PopupHoursResponseDto.java
+++ b/src/main/java/com/example/popin/domain/popup/dto/response/PopupHoursResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.popin.domain.popup.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import java.time.LocalTime;
+
+@Data
+@Builder
+public class PopupHoursResponseDto {
+    private Long id;
+    private Integer dayOfWeek;
+    private LocalTime openTime;
+    private LocalTime closeTime;
+    private String note;
+
+    public String getDayOfWeekText() {
+        String[] days = {"월", "화", "수", "목", "금", "토", "일"};
+        return dayOfWeek != null && dayOfWeek >= 0 && dayOfWeek <= 6 ? days[dayOfWeek] : "";
+    }
+
+    public String getTimeRangeText() {
+        if (openTime == null && closeTime == null) {
+            return "시간 미정";
+        }
+        return String.format("%s - %s",
+                openTime != null ? openTime.toString() : "미정",
+                closeTime != null ? closeTime.toString() : "미정");
+    }
+}

--- a/src/main/java/com/example/popin/domain/popup/dto/response/PopupImageResponseDto.java
+++ b/src/main/java/com/example/popin/domain/popup/dto/response/PopupImageResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.popin.domain.popup.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PopupImageResponseDto {
+    private Long id;
+    private String imageUrl;
+    private String caption;
+    private Integer sortOrder;
+}

--- a/src/main/java/com/example/popin/domain/popup/dto/response/PopupListResponseDto.java
+++ b/src/main/java/com/example/popin/domain/popup/dto/response/PopupListResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.popin.domain.popup.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class PopupListResponseDto {
+    private List<PopupSummaryResponseDto> popups;
+    private int totalPages;
+    private long totalElements;
+    private int currentPage;
+    private int size;
+    private boolean hasNext;
+    private boolean hasPrevious;
+}

--- a/src/main/java/com/example/popin/domain/popup/dto/response/PopupSummaryResponseDto.java
+++ b/src/main/java/com/example/popin/domain/popup/dto/response/PopupSummaryResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.popin.domain.popup.dto.response;
+
+import com.example.popin.domain.popup.entity.PopupStatus;
+import lombok.Builder;
+import lombok.Data;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class PopupSummaryResponseDto {
+    private Long id;
+    private String title;
+    private String summary;
+    private String period;
+    private PopupStatus status;
+    private String mainImageUrl;
+    private Boolean isFeatured;
+    private Boolean reservationAvailable;
+    private Boolean waitlistAvailable;
+
+    private Integer entryFee;
+    private Boolean isFreeEntry;
+    private String feeDisplayText;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private List<PopupImageResponseDto> images;
+}

--- a/src/main/java/com/example/popin/domain/popup/entity/Popup.java
+++ b/src/main/java/com/example/popin/domain/popup/entity/Popup.java
@@ -4,8 +4,8 @@ import com.example.popin.global.common.BaseEntity;
 import lombok.*;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "popups")
@@ -49,11 +49,13 @@ public class Popup extends BaseEntity {
     @Column(name = "is_featured")
     private Boolean isFeatured = false;
 
-    @OneToMany(mappedBy = "popup", cascade = CascadeType.ALL)
-    private List<PopupImage> images = new ArrayList<>();
+    @OneToMany(mappedBy = "popup", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OrderBy("sortOrder ASC")
+    private Set<PopupImage> images = new LinkedHashSet<>();
 
-    @OneToMany(mappedBy = "popup", cascade = CascadeType.ALL)
-    private List<PopupHours> hours = new ArrayList<>();
+    @OneToMany(mappedBy = "popup", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OrderBy("dayOfWeek ASC")
+    private Set<PopupHours> hours = new LinkedHashSet<>();
 
     public boolean isFreeEntry() {
         return entryFee == null || entryFee == 0;

--- a/src/main/java/com/example/popin/domain/popup/entity/Popup.java
+++ b/src/main/java/com/example/popin/domain/popup/entity/Popup.java
@@ -1,0 +1,65 @@
+package com.example.popin.domain.popup.entity;
+
+import com.example.popin.global.common.BaseEntity;
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "popups")
+@Getter @Setter
+public class Popup extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "brand_id")
+    private Long brandId;
+
+    @Column(name = "venue_id")
+    private Long venueId;
+
+    private String title;
+    private String summary;
+    private String description;
+    private String period;
+
+    @Enumerated(EnumType.STRING)
+    private PopupStatus status;
+
+    @Column(name = "entry_fee")
+    private Integer entryFee = 0;
+
+    @Column(name = "reservation_available")
+    private Boolean reservationAvailable = false;
+
+    @Column(name = "reservation_link")
+    private String reservationLink;
+
+    @Column(name = "waitlist_available")
+    private Boolean waitlistAvailable = false;
+
+    private String notice;
+
+    @Column(name = "main_image_url")
+    private String mainImageUrl;
+
+    @Column(name = "is_featured")
+    private Boolean isFeatured = false;
+
+    @OneToMany(mappedBy = "popup", cascade = CascadeType.ALL)
+    private List<PopupImage> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "popup", cascade = CascadeType.ALL)
+    private List<PopupHours> hours = new ArrayList<>();
+
+    public boolean isFreeEntry() {
+        return entryFee == null || entryFee == 0;
+    }
+
+    public String getFeeDisplayText() {
+        return isFreeEntry() ? "무료" : String.format("%,d원", entryFee);
+    }
+}

--- a/src/main/java/com/example/popin/domain/popup/entity/Popup.java
+++ b/src/main/java/com/example/popin/domain/popup/entity/Popup.java
@@ -2,6 +2,7 @@ package com.example.popin.domain.popup.entity;
 
 import com.example.popin.global.common.BaseEntity;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import javax.persistence.*;
 import java.util.LinkedHashSet;
@@ -49,11 +50,13 @@ public class Popup extends BaseEntity {
     @Column(name = "is_featured")
     private Boolean isFeatured = false;
 
-    @OneToMany(mappedBy = "popup", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "popup", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    @BatchSize(size = 50)
     @OrderBy("sortOrder ASC")
     private Set<PopupImage> images = new LinkedHashSet<>();
 
-    @OneToMany(mappedBy = "popup", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "popup", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    @BatchSize(size = 50)
     @OrderBy("dayOfWeek ASC")
     private Set<PopupHours> hours = new LinkedHashSet<>();
 

--- a/src/main/java/com/example/popin/domain/popup/entity/PopupHours.java
+++ b/src/main/java/com/example/popin/domain/popup/entity/PopupHours.java
@@ -1,0 +1,33 @@
+package com.example.popin.domain.popup.entity;
+
+import com.example.popin.global.common.BaseEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "popup_hours")
+@Getter
+@Setter
+public class PopupHours extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "popup_id")
+    private Popup popup;
+
+    @Column(name = "day_of_week")
+    private Integer dayOfWeek; // 0=Mon..6=Sun
+
+    @Column(name = "open_time")
+    private LocalTime openTime;
+
+    @Column(name = "close_time")
+    private LocalTime closeTime;
+
+    private String note;
+}

--- a/src/main/java/com/example/popin/domain/popup/entity/PopupHours.java
+++ b/src/main/java/com/example/popin/domain/popup/entity/PopupHours.java
@@ -16,11 +16,11 @@ public class PopupHours extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "popup_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "popup_id", nullable = false)
     private Popup popup;
 
-    @Column(name = "day_of_week")
+    @Column(name = "day_of_week", nullable = false)
     private Integer dayOfWeek; // 0=Mon..6=Sun
 
     @Column(name = "open_time")

--- a/src/main/java/com/example/popin/domain/popup/entity/PopupImage.java
+++ b/src/main/java/com/example/popin/domain/popup/entity/PopupImage.java
@@ -1,0 +1,29 @@
+package com.example.popin.domain.popup.entity;
+
+import com.example.popin.global.common.BaseEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "popup_images")
+@Getter
+@Setter
+public class PopupImage extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "popup_id")
+    private Popup popup;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    private String caption;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder = 0;
+}

--- a/src/main/java/com/example/popin/domain/popup/entity/PopupImage.java
+++ b/src/main/java/com/example/popin/domain/popup/entity/PopupImage.java
@@ -15,15 +15,20 @@ public class PopupImage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "popup_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "popup_id", nullable = false)
     private Popup popup;
 
-    @Column(name = "image_url")
+    @Column(name = "image_url", nullable = false, length = 2048)
     private String imageUrl;
 
     private String caption;
 
     @Column(name = "sort_order")
     private Integer sortOrder = 0;
+
+    @PrePersist
+    void prePersist() {
+        if (sortOrder == null) sortOrder = 0;
+    }
 }

--- a/src/main/java/com/example/popin/domain/popup/entity/PopupStatus.java
+++ b/src/main/java/com/example/popin/domain/popup/entity/PopupStatus.java
@@ -1,0 +1,5 @@
+package com.example.popin.domain.popup.entity;
+
+public enum PopupStatus {
+    PLANNED, ONGOING, ENDED
+}

--- a/src/main/java/com/example/popin/domain/popup/repository/PopupRepository.java
+++ b/src/main/java/com/example/popin/domain/popup/repository/PopupRepository.java
@@ -1,0 +1,24 @@
+package com.example.popin.domain.popup.repository;
+
+import com.example.popin.domain.popup.entity.Popup;
+import com.example.popin.domain.popup.entity.PopupStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PopupRepository extends JpaRepository<Popup, Long> {
+
+    // 전체 팝업 조회 (상태별)
+    Page<Popup> findByStatusOrderByCreatedAtDesc(PopupStatus status, Pageable pageable);
+
+    // 모든 상태의 팝업 조회
+    Page<Popup> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    // 팝업 상세 조회 (이미지, 시간 정보 포함)
+    @Query("SELECT p FROM Popup p LEFT JOIN FETCH p.images LEFT JOIN FETCH p.hours WHERE p.id = :id")
+    Popup findByIdWithDetails(@Param("id") Long id);
+}

--- a/src/main/java/com/example/popin/domain/popup/repository/PopupRepository.java
+++ b/src/main/java/com/example/popin/domain/popup/repository/PopupRepository.java
@@ -4,10 +4,13 @@ import com.example.popin.domain.popup.entity.Popup;
 import com.example.popin.domain.popup.entity.PopupStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface PopupRepository extends JpaRepository<Popup, Long> {
@@ -19,6 +22,7 @@ public interface PopupRepository extends JpaRepository<Popup, Long> {
     Page<Popup> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     // 팝업 상세 조회 (이미지, 시간 정보 포함)
-    @Query("SELECT p FROM Popup p LEFT JOIN FETCH p.images LEFT JOIN FETCH p.hours WHERE p.id = :id")
-    Popup findByIdWithDetails(@Param("id") Long id);
+    @EntityGraph(attributePaths = {"images", "hours"})
+    @Query("SELECT p FROM Popup p WHERE p.id = :id")
+    Optional<Popup> findByIdWithDetails(@Param("id") Long id);
 }

--- a/src/main/java/com/example/popin/domain/popup/service/PopupService.java
+++ b/src/main/java/com/example/popin/domain/popup/service/PopupService.java
@@ -4,6 +4,7 @@ import com.example.popin.domain.popup.dto.request.PopupListRequestDto;
 import com.example.popin.domain.popup.dto.response.*;
 import com.example.popin.domain.popup.entity.*;
 import com.example.popin.domain.popup.repository.PopupRepository;
+import com.example.popin.global.exception.PopupNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
@@ -45,10 +46,7 @@ public class PopupService {
 
     public PopupDetailResponseDto getPopupDetail(Long popupId) {
         Popup popup = popupRepository.findByIdWithDetails(popupId)
-                .orElseThrow(() -> {
-                    log.warn("팝업을 찾을 수 없습니다 - ID: {}", popupId);
-                    return new ResponseStatusException(HttpStatus.NOT_FOUND, "Popup not found: " + popupId);
-                });
+                .orElseThrow(() -> new PopupNotFoundException(popupId));
 
         log.info("팝업 상세 조회 완료 - ID: {}, 제목: {}, 이미지 수: {}, 운영시간 수: {}",
                 popup.getId(), popup.getTitle(), popup.getImages().size(), popup.getHours().size());

--- a/src/main/java/com/example/popin/domain/popup/service/PopupService.java
+++ b/src/main/java/com/example/popin/domain/popup/service/PopupService.java
@@ -5,13 +5,17 @@ import com.example.popin.domain.popup.dto.response.*;
 import com.example.popin.domain.popup.entity.*;
 import com.example.popin.domain.popup.repository.PopupRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -40,10 +44,14 @@ public class PopupService {
     }
 
     public PopupDetailResponseDto getPopupDetail(Long popupId) {
-        Popup popup = popupRepository.findByIdWithDetails(popupId);
-        if (popup == null) {
-            throw new IllegalArgumentException("팝업을 찾을 수 없습니다: " + popupId);
-        }
+        Popup popup = popupRepository.findByIdWithDetails(popupId)
+                .orElseThrow(() -> {
+                    log.warn("팝업을 찾을 수 없습니다 - ID: {}", popupId);
+                    return new ResponseStatusException(HttpStatus.NOT_FOUND, "Popup not found: " + popupId);
+                });
+
+        log.info("팝업 상세 조회 완료 - ID: {}, 제목: {}, 이미지 수: {}, 운영시간 수: {}",
+                popup.getId(), popup.getTitle(), popup.getImages().size(), popup.getHours().size());
         return convertToDetailResponseDto(popup);
     }
 

--- a/src/main/java/com/example/popin/domain/popup/service/PopupService.java
+++ b/src/main/java/com/example/popin/domain/popup/service/PopupService.java
@@ -1,0 +1,145 @@
+package com.example.popin.domain.popup.service;
+
+import com.example.popin.domain.popup.dto.request.PopupListRequestDto;
+import com.example.popin.domain.popup.dto.response.*;
+import com.example.popin.domain.popup.entity.*;
+import com.example.popin.domain.popup.repository.PopupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PopupService {
+
+    private final PopupRepository popupRepository;
+
+    public PopupListResponseDto getPopupList(PopupListRequestDto request) {
+        Pageable pageable = createPageable(request);
+        Page<Popup> popupPage = getPopups(request.getStatus(), pageable);
+
+        List<PopupSummaryResponseDto> popupDtos = popupPage.getContent()
+                .stream()
+                .map(this::convertToSummaryResponseDto)
+                .collect(Collectors.toList());
+
+        return PopupListResponseDto.builder()
+                .popups(popupDtos)
+                .totalPages(popupPage.getTotalPages())
+                .totalElements(popupPage.getTotalElements())
+                .currentPage(popupPage.getNumber())
+                .size(popupPage.getSize())
+                .hasNext(popupPage.hasNext())
+                .hasPrevious(popupPage.hasPrevious())
+                .build();
+    }
+
+    public PopupDetailResponseDto getPopupDetail(Long popupId) {
+        Popup popup = popupRepository.findByIdWithDetails(popupId);
+        if (popup == null) {
+            throw new IllegalArgumentException("팝업을 찾을 수 없습니다: " + popupId);
+        }
+        return convertToDetailResponseDto(popup);
+    }
+
+    private Page<Popup> getPopups(PopupStatus status, Pageable pageable) {
+        if (status != null) {
+            return popupRepository.findByStatusOrderByCreatedAtDesc(status, pageable);
+        } else {
+            return popupRepository.findAllByOrderByCreatedAtDesc(pageable);
+        }
+    }
+
+    private PopupSummaryResponseDto convertToSummaryResponseDto(Popup popup) {
+        List<PopupImageResponseDto> imageDtos = popup.getImages().stream()
+                .map(this::convertToImageResponseDto)
+                .collect(Collectors.toList());
+
+        return PopupSummaryResponseDto.builder()
+                .id(popup.getId())
+                .title(popup.getTitle())
+                .summary(popup.getSummary())
+                .period(popup.getPeriod())
+                .status(popup.getStatus())
+                .mainImageUrl(popup.getMainImageUrl())
+                .isFeatured(popup.getIsFeatured())
+                .reservationAvailable(popup.getReservationAvailable())
+                .waitlistAvailable(popup.getWaitlistAvailable())
+                .entryFee(popup.getEntryFee())
+                .isFreeEntry(popup.isFreeEntry())
+                .feeDisplayText(popup.getFeeDisplayText())
+                .createdAt(popup.getCreatedAt())
+                .updatedAt(popup.getUpdatedAt())
+                .images(imageDtos)
+                .build();
+    }
+
+    private PopupDetailResponseDto convertToDetailResponseDto(Popup popup) {
+        List<PopupImageResponseDto> imageDtos = popup.getImages().stream()
+                .map(this::convertToImageResponseDto)
+                .collect(Collectors.toList());
+
+        List<PopupHoursResponseDto> hoursDtos = popup.getHours().stream()
+                .map(this::convertToHoursResponseDto)
+                .collect(Collectors.toList());
+
+        return PopupDetailResponseDto.builder()
+                .id(popup.getId())
+                .brandId(popup.getBrandId())
+                .venueId(popup.getVenueId())
+                .title(popup.getTitle())
+                .summary(popup.getSummary())
+                .description(popup.getDescription())
+                .period(popup.getPeriod())
+                .status(popup.getStatus())
+                .mainImageUrl(popup.getMainImageUrl())
+                .isFeatured(popup.getIsFeatured())
+                .reservationAvailable(popup.getReservationAvailable())
+                .reservationLink(popup.getReservationLink())
+                .waitlistAvailable(popup.getWaitlistAvailable())
+                .entryFee(popup.getEntryFee())
+                .isFreeEntry(popup.isFreeEntry())
+                .feeDisplayText(popup.getFeeDisplayText())
+                .notice(popup.getNotice())
+                .createdAt(popup.getCreatedAt())
+                .updatedAt(popup.getUpdatedAt())
+                .images(imageDtos)
+                .hours(hoursDtos)
+                .build();
+    }
+
+    private PopupImageResponseDto convertToImageResponseDto(PopupImage image) {
+        return PopupImageResponseDto.builder()
+                .id(image.getId())
+                .imageUrl(image.getImageUrl())
+                .caption(image.getCaption())
+                .sortOrder(image.getSortOrder())
+                .build();
+    }
+
+    private PopupHoursResponseDto convertToHoursResponseDto(PopupHours hours) {
+        return PopupHoursResponseDto.builder()
+                .id(hours.getId())
+                .dayOfWeek(hours.getDayOfWeek())
+                .openTime(hours.getOpenTime())
+                .closeTime(hours.getCloseTime())
+                .note(hours.getNote())
+                .build();
+    }
+
+    private Pageable createPageable(PopupListRequestDto request) {
+        Sort sort = Sort.by(
+                request.getSortDirection().equalsIgnoreCase("ASC")
+                        ? Sort.Direction.ASC
+                        : Sort.Direction.DESC,
+                request.getSortBy()
+        );
+        return PageRequest.of(request.getPage(), request.getSize(), sort);
+    }
+}

--- a/src/main/java/com/example/popin/domain/popup/service/PopupService.java
+++ b/src/main/java/com/example/popin/domain/popup/service/PopupService.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor

--- a/src/main/java/com/example/popin/global/constant/ErrorCode.java
+++ b/src/main/java/com/example/popin/global/constant/ErrorCode.java
@@ -27,8 +27,11 @@ public enum ErrorCode {
 
     INVALID_TOKEN(20003, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     ACCESS_DENIED(20004, HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
-    UNAUTHORIZED(20005, HttpStatus.UNAUTHORIZED, "권한이 없습니다.")
+    UNAUTHORIZED(20005, HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
 
+    POPUP_NOT_FOUND(40404, HttpStatus.NOT_FOUND, "팝업을 찾을 수 없습니다"),
+    POPUP_ACCESS_DENIED(40304, HttpStatus.FORBIDDEN, "팝업 접근 권한이 없습니다"),
+    POPUP_ALREADY_ENDED(40004, HttpStatus.BAD_REQUEST, "이미 종료된 팝업입니다"),
     ;
 
     private final Integer code;

--- a/src/main/java/com/example/popin/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/example/popin/global/exception/ApiExceptionHandler.java
@@ -31,6 +31,16 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(e, ErrorCode.INTERNAL_ERROR, request);
     }
 
+    @ExceptionHandler(PopupNotFoundException.class)
+    public ResponseEntity<Object> handlePopupNotFound(PopupNotFoundException e, WebRequest request) {
+        ErrorCode errorCode = e.getErrorCode();
+        ApiErrorResponse errorResponse = ApiErrorResponse.of(errorCode, e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(errorResponse);
+    }
+
     @Override
     protected ResponseEntity<Object> handleExceptionInternal(
             Exception ex, Object body, HttpHeaders headers, HttpStatus status, WebRequest request) {

--- a/src/main/java/com/example/popin/global/exception/PopupNotFoundException.java
+++ b/src/main/java/com/example/popin/global/exception/PopupNotFoundException.java
@@ -1,0 +1,29 @@
+package com.example.popin.global.exception;
+
+import com.example.popin.global.constant.ErrorCode;
+
+public class PopupNotFoundException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final Long popupId;
+
+    public PopupNotFoundException(Long popupId) {
+        super("팝업을 찾을 수 없습니다: " + popupId);
+        this.errorCode = ErrorCode.POPUP_NOT_FOUND; // ErrorCode enum에 추가 필요
+        this.popupId = popupId;
+    }
+
+    public PopupNotFoundException(String message) {
+        super(message);
+        this.errorCode = ErrorCode.POPUP_NOT_FOUND;
+        this.popupId = null;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public Long getPopupId() {
+        return popupId;
+    }
+}

--- a/src/test/java/com/example/popin/popup/controller/PopupControllerTest.java
+++ b/src/test/java/com/example/popin/popup/controller/PopupControllerTest.java
@@ -1,0 +1,173 @@
+package com.example.popin.popup.controller;
+
+import com.example.popin.domain.popup.entity.Popup;
+import com.example.popin.domain.popup.entity.PopupStatus;
+import com.example.popin.domain.popup.repository.PopupRepository;
+import com.example.popin.popup.testdata.PopupTestDataBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@Transactional
+@DisplayName("PopupController 통합 테스트")
+public class PopupControllerTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private PopupRepository popupRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockMvc mockMvc;
+
+    private Popup savedPopup1;
+    private Popup savedPopup2;
+    private Popup savedPopup3;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+
+        // 테스트 데이터 저장
+        savedPopup1 = popupRepository.save(
+                PopupTestDataBuilder.createCompletePopup("무료 팝업스토어", PopupStatus.ONGOING, 0)
+        );
+        savedPopup2 = popupRepository.save(
+                PopupTestDataBuilder.createCompletePopup("유료 팝업스토어", PopupStatus.ONGOING, 8000)
+        );
+        savedPopup3 = popupRepository.save(
+                PopupTestDataBuilder.createCompletePopup("계획된 팝업스토어", PopupStatus.PLANNED, 5000)
+        );
+    }
+
+    @Test
+    @DisplayName("팝업 리스트 조회 - 전체")
+    void getPopupList_All() throws Exception {
+        mockMvc.perform(get("/api/popups")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.popups").isArray())
+                .andExpect(jsonPath("$.popups.length()").value(3))
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.currentPage").value(0))
+                .andExpect(jsonPath("$.size").value(10))
+                .andExpect(jsonPath("$.popups[0].title").exists())
+                .andExpect(jsonPath("$.popups[0].entryFee").exists())
+                .andExpect(jsonPath("$.popups[0].feeDisplayText").exists())
+                .andExpect(jsonPath("$.popups[0].images").isArray());
+    }
+
+    @Test
+    @DisplayName("팝업 리스트 조회 - 상태별 (ONGOING)")
+    void getPopupList_ByStatus() throws Exception {
+        mockMvc.perform(get("/api/popups")
+                        .param("status", "ONGOING")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.popups").isArray())
+                .andExpect(jsonPath("$.popups.length()").value(2))
+                .andExpect(jsonPath("$.popups[0].status").value("ONGOING"))
+                .andExpect(jsonPath("$.popups[1].status").value("ONGOING"));
+    }
+
+    @Test
+    @DisplayName("팝업 리스트 조회 - 페이징")
+    void getPopupList_WithPaging() throws Exception {
+        mockMvc.perform(get("/api/popups")
+                        .param("page", "0")
+                        .param("size", "2"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.popups.length()").value(2))
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.totalPages").value(2))
+                .andExpect(jsonPath("$.hasNext").value(true))
+                .andExpect(jsonPath("$.hasPrevious").value(false));
+    }
+
+    @Test
+    @DisplayName("팝업 리스트 조회 - 정렬")
+    void getPopupList_WithSort() throws Exception {
+        mockMvc.perform(get("/api/popups")
+                        .param("sortBy", "title")
+                        .param("sortDirection", "ASC"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.popups").isArray());
+    }
+
+    @Test
+    @DisplayName("팝업 상세 조회 - 성공")
+    void getPopupDetail_Success() throws Exception {
+        mockMvc.perform(get("/api/popups/{popupId}", savedPopup1.getId()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(savedPopup1.getId()))
+                .andExpect(jsonPath("$.title").value("무료 팝업스토어"))
+                .andExpect(jsonPath("$.description").exists())
+                .andExpect(jsonPath("$.entryFee").value(0))
+                .andExpect(jsonPath("$.isFreeEntry").value(true))
+                .andExpect(jsonPath("$.feeDisplayText").value("무료"))
+                .andExpect(jsonPath("$.reservationAvailable").value(false))
+                .andExpect(jsonPath("$.images").isArray())
+                .andExpect(jsonPath("$.images.length()").value(2))
+                .andExpect(jsonPath("$.hours").isArray())
+                .andExpect(jsonPath("$.hours.length()").value(7))
+                .andExpect(jsonPath("$.brandId").exists())
+                .andExpect(jsonPath("$.venueId").exists());
+    }
+
+    @Test
+    @DisplayName("팝업 상세 조회 - 유료 팝업")
+    void getPopupDetail_PaidPopup() throws Exception {
+        mockMvc.perform(get("/api/popups/{popupId}", savedPopup2.getId()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.entryFee").value(8000))
+                .andExpect(jsonPath("$.isFreeEntry").value(false))
+                .andExpect(jsonPath("$.feeDisplayText").value("8,000원"))
+                .andExpect(jsonPath("$.reservationAvailable").value(true))
+                .andExpect(jsonPath("$.reservationLink").exists());
+    }
+
+    @Test
+    @DisplayName("팝업 상세 조회 - 존재하지 않는 팝업")
+    void getPopupDetail_NotFound() throws Exception {
+        mockMvc.perform(get("/api/popups/{popupId}", 999L))
+                .andDo(print())
+                .andExpect(status().isInternalServerError()); // 현재 IllegalArgumentException으로 처리됨
+    }
+
+    @Test
+    @DisplayName("팝업 리스트 조회 - 잘못된 파라미터")
+    void getPopupList_InvalidParameters() throws Exception {
+        mockMvc.perform(get("/api/popups")
+                        .param("page", "-1")
+                        .param("size", "0"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/example/popin/popup/controller/PopupControllerTest.java
+++ b/src/test/java/com/example/popin/popup/controller/PopupControllerTest.java
@@ -158,7 +158,7 @@ public class PopupControllerTest {
     void getPopupDetail_NotFound() throws Exception {
         mockMvc.perform(get("/api/popups/{popupId}", 999L))
                 .andDo(print())
-                .andExpect(status().isInternalServerError()); // 현재 IllegalArgumentException으로 처리됨
+                .andExpect(status().isNotFound());
     }
 
     @Test

--- a/src/test/java/com/example/popin/popup/repository/PopupRepositoryTest.java
+++ b/src/test/java/com/example/popin/popup/repository/PopupRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.example.popin.popup.repository;
+
+import com.example.popin.domain.popup.entity.Popup;
+import com.example.popin.domain.popup.entity.PopupStatus;
+import com.example.popin.domain.popup.repository.PopupRepository;
+import com.example.popin.popup.testdata.PopupTestDataBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@DataJpaTest
+@DisplayName("PopupRepository 테스트")
+class PopupRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private PopupRepository popupRepository;
+
+    private Popup ongoingPopup1;
+    private Popup ongoingPopup2;
+    private Popup plannedPopup;
+    private Popup endedPopup;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 데이터 생성
+        ongoingPopup1 = PopupTestDataBuilder.createCompletePopup("진행중 팝업1", PopupStatus.ONGOING, 0);
+        ongoingPopup2 = PopupTestDataBuilder.createCompletePopup("진행중 팝업2", PopupStatus.ONGOING, 5000);
+        plannedPopup = PopupTestDataBuilder.createCompletePopup("계획된 팝업", PopupStatus.PLANNED, 3000);
+        endedPopup = PopupTestDataBuilder.createCompletePopup("종료된 팝업", PopupStatus.ENDED, 0);
+
+        entityManager.persistAndFlush(ongoingPopup1);
+        entityManager.persistAndFlush(ongoingPopup2);
+        entityManager.persistAndFlush(plannedPopup);
+        entityManager.persistAndFlush(endedPopup);
+    }
+
+    @Test
+    @DisplayName("상태별 팝업 조회 - ONGOING")
+    void findByStatusOrderByCreatedAtDesc_Ongoing() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Popup> result = popupRepository.findByStatusOrderByCreatedAtDesc(PopupStatus.ONGOING, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent())
+                .extracting(Popup::getStatus)
+                .containsOnly(PopupStatus.ONGOING);
+        assertThat(result.getContent().get(0).getTitle()).contains("진행중 팝업");
+    }
+
+    @Test
+    @DisplayName("전체 팝업 조회")
+    void findAllByOrderByCreatedAtDesc() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Popup> result = popupRepository.findAllByOrderByCreatedAtDesc(pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(4);
+        assertThat(result.getTotalElements()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("상세 조회 - 이미지와 운영시간 포함")
+    void findByIdWithDetails() {
+        // when
+        Popup result = popupRepository.findByIdWithDetails(ongoingPopup1.getId());
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getTitle()).isEqualTo("진행중 팝업1");
+        assertThat(result.getImages()).hasSize(2);
+        assertThat(result.getHours()).hasSize(7);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID로 상세 조회")
+    void findByIdWithDetails_NotFound() {
+        // when
+        Popup result = popupRepository.findByIdWithDetails(999L);
+
+        // then
+        assertThat(result).isNull();
+    }
+}

--- a/src/test/java/com/example/popin/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/example/popin/popup/service/PopupServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -112,7 +113,7 @@ public class PopupServiceTest {
         // given
         Long popupId = 3L;
         given(popupRepository.findByIdWithDetails(popupId))
-                .willReturn(detailPopup);
+                .willReturn(Optional.of(detailPopup));
 
         // when
         PopupDetailResponseDto response = popupService.getPopupDetail(popupId);
@@ -135,7 +136,7 @@ public class PopupServiceTest {
         // given
         Long popupId = 999L;
         given(popupRepository.findByIdWithDetails(popupId))
-                .willReturn(null);
+                .willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> popupService.getPopupDetail(popupId))

--- a/src/test/java/com/example/popin/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/example/popin/popup/service/PopupServiceTest.java
@@ -1,0 +1,145 @@
+package com.example.popin.popup.service;
+
+import com.example.popin.domain.popup.dto.request.PopupListRequestDto;
+import com.example.popin.domain.popup.dto.response.PopupDetailResponseDto;
+import com.example.popin.domain.popup.dto.response.PopupListResponseDto;
+import com.example.popin.domain.popup.dto.response.PopupSummaryResponseDto;
+import com.example.popin.domain.popup.entity.Popup;
+import com.example.popin.domain.popup.entity.PopupStatus;
+import com.example.popin.domain.popup.repository.PopupRepository;
+import com.example.popin.domain.popup.service.PopupService;
+import com.example.popin.popup.testdata.PopupTestDataBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PopupService 테스트")
+public class PopupServiceTest {
+
+    @Mock
+    private PopupRepository popupRepository;
+
+    @InjectMocks
+    private PopupService popupService;
+
+    private Popup samplePopup1;
+    private Popup samplePopup2;
+    private Popup detailPopup;
+
+    @BeforeEach
+    void setUp() {
+        samplePopup1 = PopupTestDataBuilder.createCompletePopup("무료 팝업", PopupStatus.ONGOING, 0);
+        samplePopup1.setId(1L);
+
+        samplePopup2 = PopupTestDataBuilder.createCompletePopup("유료 팝업", PopupStatus.ONGOING, 10000);
+        samplePopup2.setId(2L);
+
+        detailPopup = PopupTestDataBuilder.createCompletePopup("상세 팝업", PopupStatus.ONGOING, 5000);
+        detailPopup.setId(3L);
+    }
+
+    @Test
+    @DisplayName("팝업 리스트 조회 - 전체")
+    void getPopupList_All() {
+        // given
+        List<Popup> popups = Arrays.asList(samplePopup1, samplePopup2);
+        Page<Popup> popupPage = new PageImpl<>(popups, PageRequest.of(0, 20), 2);
+
+        PopupListRequestDto request = new PopupListRequestDto();
+        request.setStatus(null); // 전체 조회
+
+        given(popupRepository.findAllByOrderByCreatedAtDesc(any(Pageable.class)))
+                .willReturn(popupPage);
+
+        // when
+        PopupListResponseDto response = popupService.getPopupList(request);
+
+        // then
+        assertThat(response.getPopups()).hasSize(2);
+        assertThat(response.getTotalElements()).isEqualTo(2);
+        assertThat(response.getCurrentPage()).isEqualTo(0);
+        assertThat(response.getSize()).isEqualTo(20);
+
+        PopupSummaryResponseDto firstPopup = response.getPopups().get(0);
+        assertThat(firstPopup.getTitle()).isEqualTo("무료 팝업");
+        assertThat(firstPopup.getIsFreeEntry()).isTrue();
+        assertThat(firstPopup.getFeeDisplayText()).isEqualTo("무료");
+        assertThat(firstPopup.getImages()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("팝업 리스트 조회 - 상태별")
+    void getPopupList_ByStatus() {
+        // given
+        List<Popup> popups = Arrays.asList(samplePopup1);
+        Page<Popup> popupPage = new PageImpl<>(popups, PageRequest.of(0, 20), 1);
+
+        PopupListRequestDto request = new PopupListRequestDto();
+        request.setStatus(PopupStatus.ONGOING);
+
+        given(popupRepository.findByStatusOrderByCreatedAtDesc(eq(PopupStatus.ONGOING), any(Pageable.class)))
+                .willReturn(popupPage);
+
+        // when
+        PopupListResponseDto response = popupService.getPopupList(request);
+
+        // then
+        assertThat(response.getPopups()).hasSize(1);
+        assertThat(response.getPopups().get(0).getStatus()).isEqualTo(PopupStatus.ONGOING);
+    }
+
+    @Test
+    @DisplayName("팝업 상세 조회 - 성공")
+    void getPopupDetail_Success() {
+        // given
+        Long popupId = 3L;
+        given(popupRepository.findByIdWithDetails(popupId))
+                .willReturn(detailPopup);
+
+        // when
+        PopupDetailResponseDto response = popupService.getPopupDetail(popupId);
+
+        // then
+        assertThat(response.getId()).isEqualTo(3L);
+        assertThat(response.getTitle()).isEqualTo("상세 팝업");
+        assertThat(response.getDescription()).isEqualTo("상세 팝업 상세 설명입니다.");
+        assertThat(response.getEntryFee()).isEqualTo(5000);
+        assertThat(response.getIsFreeEntry()).isFalse();
+        assertThat(response.getFeeDisplayText()).isEqualTo("5,000원");
+        assertThat(response.getImages()).hasSize(2);
+        assertThat(response.getHours()).hasSize(7);
+        assertThat(response.getReservationAvailable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("팝업 상세 조회 - 존재하지 않는 팝업")
+    void getPopupDetail_NotFound() {
+        // given
+        Long popupId = 999L;
+        given(popupRepository.findByIdWithDetails(popupId))
+                .willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> popupService.getPopupDetail(popupId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("팝업을 찾을 수 없습니다: " + popupId);
+    }
+}

--- a/src/test/java/com/example/popin/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/example/popin/popup/service/PopupServiceTest.java
@@ -8,6 +8,7 @@ import com.example.popin.domain.popup.entity.Popup;
 import com.example.popin.domain.popup.entity.PopupStatus;
 import com.example.popin.domain.popup.repository.PopupRepository;
 import com.example.popin.domain.popup.service.PopupService;
+import com.example.popin.global.exception.PopupNotFoundException;
 import com.example.popin.popup.testdata.PopupTestDataBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -140,7 +141,7 @@ public class PopupServiceTest {
 
         // when & then
         assertThatThrownBy(() -> popupService.getPopupDetail(popupId))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(PopupNotFoundException.class)
                 .hasMessage("팝업을 찾을 수 없습니다: " + popupId);
     }
 }

--- a/src/test/java/com/example/popin/popup/testdata/PopupTestDataBuilder.java
+++ b/src/test/java/com/example/popin/popup/testdata/PopupTestDataBuilder.java
@@ -6,8 +6,8 @@ import com.example.popin.domain.popup.entity.PopupImage;
 import com.example.popin.domain.popup.entity.PopupStatus;
 
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 public class PopupTestDataBuilder {
 
@@ -52,7 +52,7 @@ public class PopupTestDataBuilder {
     public static Popup createPopupWithImages(String title, PopupStatus status, Integer entryFee) {
         Popup popup = createPopup(title, status, entryFee);
 
-        List<PopupImage> images = new ArrayList<>();
+        Set<PopupImage> images = new LinkedHashSet<>();
         images.add(createPopupImage(popup, "https://example.com/image1.jpg", "메인 이미지", 0));
         images.add(createPopupImage(popup, "https://example.com/image2.jpg", "서브 이미지", 1));
         popup.setImages(images);
@@ -63,7 +63,7 @@ public class PopupTestDataBuilder {
     public static Popup createPopupWithHours(String title, PopupStatus status, Integer entryFee) {
         Popup popup = createPopup(title, status, entryFee);
 
-        List<PopupHours> hours = new ArrayList<>();
+        Set<PopupHours> hours = new LinkedHashSet<>();
         // 평일 (월~금)
         for (int i = 0; i < 5; i++) {
             hours.add(createPopupHours(popup, i, "10:00", "20:00"));
@@ -81,13 +81,13 @@ public class PopupTestDataBuilder {
         Popup popup = createPopup(title, status, entryFee);
 
         // 이미지 추가
-        List<PopupImage> images = new ArrayList<>();
+        Set<PopupImage> images = new LinkedHashSet<>();
         images.add(createPopupImage(popup, "https://example.com/image1.jpg", "메인 이미지", 0));
         images.add(createPopupImage(popup, "https://example.com/image2.jpg", "서브 이미지", 1));
         popup.setImages(images);
 
         // 운영시간 추가
-        List<PopupHours> hours = new ArrayList<>();
+        Set<PopupHours> hours = new LinkedHashSet<>();
         for (int i = 0; i < 7; i++) {
             if (i < 5) { // 평일
                 hours.add(createPopupHours(popup, i, "10:00", "20:00"));

--- a/src/test/java/com/example/popin/popup/testdata/PopupTestDataBuilder.java
+++ b/src/test/java/com/example/popin/popup/testdata/PopupTestDataBuilder.java
@@ -1,0 +1,102 @@
+package com.example.popin.popup.testdata;
+
+import com.example.popin.domain.popup.entity.Popup;
+import com.example.popin.domain.popup.entity.PopupHours;
+import com.example.popin.domain.popup.entity.PopupImage;
+import com.example.popin.domain.popup.entity.PopupStatus;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PopupTestDataBuilder {
+
+    public static Popup createPopup(String title, PopupStatus status, Integer entryFee) {
+        Popup popup = new Popup();
+        popup.setTitle(title);
+        popup.setSummary(title + " 요약");
+        popup.setDescription(title + " 상세 설명입니다.");
+        popup.setPeriod("2025-09-01 ~ 2025-09-30");
+        popup.setStatus(status);
+        popup.setEntryFee(entryFee);
+        popup.setReservationAvailable(entryFee > 0); // 유료면 예약 가능
+        popup.setReservationLink(entryFee > 0 ? "https://booking.example.com" : null);
+        popup.setWaitlistAvailable(false);
+        popup.setNotice("공지사항입니다.");
+        popup.setMainImageUrl("https://example.com/main.jpg");
+        popup.setIsFeatured(entryFee == 0); // 무료면 추천
+        popup.setBrandId(1L);
+        popup.setVenueId(1L);
+        return popup;
+    }
+
+    public static PopupImage createPopupImage(Popup popup, String imageUrl, String caption, Integer sortOrder) {
+        PopupImage image = new PopupImage();
+        image.setPopup(popup);
+        image.setImageUrl(imageUrl);
+        image.setCaption(caption);
+        image.setSortOrder(sortOrder);
+        return image;
+    }
+
+    public static PopupHours createPopupHours(Popup popup, Integer dayOfWeek, String openTime, String closeTime) {
+        PopupHours hours = new PopupHours();
+        hours.setPopup(popup);
+        hours.setDayOfWeek(dayOfWeek);
+        hours.setOpenTime(LocalTime.parse(openTime));
+        hours.setCloseTime(LocalTime.parse(closeTime));
+        hours.setNote(dayOfWeek < 5 ? "평일" : "주말");
+        return hours;
+    }
+
+    public static Popup createPopupWithImages(String title, PopupStatus status, Integer entryFee) {
+        Popup popup = createPopup(title, status, entryFee);
+
+        List<PopupImage> images = new ArrayList<>();
+        images.add(createPopupImage(popup, "https://example.com/image1.jpg", "메인 이미지", 0));
+        images.add(createPopupImage(popup, "https://example.com/image2.jpg", "서브 이미지", 1));
+        popup.setImages(images);
+
+        return popup;
+    }
+
+    public static Popup createPopupWithHours(String title, PopupStatus status, Integer entryFee) {
+        Popup popup = createPopup(title, status, entryFee);
+
+        List<PopupHours> hours = new ArrayList<>();
+        // 평일 (월~금)
+        for (int i = 0; i < 5; i++) {
+            hours.add(createPopupHours(popup, i, "10:00", "20:00"));
+        }
+        // 주말 (토~일)
+        for (int i = 5; i < 7; i++) {
+            hours.add(createPopupHours(popup, i, "11:00", "19:00"));
+        }
+        popup.setHours(hours);
+
+        return popup;
+    }
+
+    public static Popup createCompletePopup(String title, PopupStatus status, Integer entryFee) {
+        Popup popup = createPopup(title, status, entryFee);
+
+        // 이미지 추가
+        List<PopupImage> images = new ArrayList<>();
+        images.add(createPopupImage(popup, "https://example.com/image1.jpg", "메인 이미지", 0));
+        images.add(createPopupImage(popup, "https://example.com/image2.jpg", "서브 이미지", 1));
+        popup.setImages(images);
+
+        // 운영시간 추가
+        List<PopupHours> hours = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            if (i < 5) { // 평일
+                hours.add(createPopupHours(popup, i, "10:00", "20:00"));
+            } else { // 주말
+                hours.add(createPopupHours(popup, i, "11:00", "19:00"));
+            }
+        }
+        popup.setHours(hours);
+
+        return popup;
+    }
+}


### PR DESCRIPTION
## 📌 Summary
- resolve: #4 
- Related Jira: POP-45

## ✨ Description
<!-- 변경 사항 요약 -->
### 메인에 보여질 팝업 리스트 조회 기능을 구현했습니다.
- ERD 기반 `popup`, `popup_hours`, `popup_images` table을 구현했습니다.
    - `PopupStatus` enum은 `PLANNED, ONGOING, ENDED` 3가지 상태록 구성
- DTO
    - `PopupListRequestDto`: 리스트 조회 요청 파라미터
    - `PopupListResponseDto`: 리스트 조회 응답 래퍼
    - `PopupSummaryResponseDto`: 리스트 아이템용 (간단한 정보)
    - `PopupDetailResponseDto`: 상세 조회용 (전체 정보)
    - `PopupImageResponseDto`: 이미지 정보
    - `PopupHoursResponseDto`: 운영시간 정보
- Repository
    - 전체 조회, 상태별 조회, 상세 조회 구현

## 🗒️ Review Point
```
아직 카테고리와 연동되지 않아 전체 조회와 상태별 조회, 상세 조회만 구현해 두었습니다.
추후 카테고리별 조회 및 정렬 기능을 추가할 예정입니다.
```

## ✅ CheckList
- [ ] 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API to browse popups:
    * GET /api/popups — pagination, sorting, optional status filter; returns summaries with images, pricing, featured and reservation flags, and pagination metadata.
    * GET /api/popups/{id} — detailed view with images, operating hours, reservation info, entry-fee display, and free/paid indicator.
* **Bug Fixes/Validation**
  * Request validation for paging parameters (400) and explicit 404 handling when a popup is not found.
* **Tests**
  * Added unit and integration tests covering listing, filtering, paging, sorting, and detail retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->