### PR TITLE
Feature #POP-66 리워드 수령

### DIFF
--- a/src/main/java/com/example/popin/domain/mission/controller/MissionSetController.java
+++ b/src/main/java/com/example/popin/domain/mission/controller/MissionSetController.java
@@ -24,15 +24,18 @@ public class MissionSetController {
     @GetMapping("/{missionSetId}")
     public MissionSetViewDto byMissionSet(@PathVariable UUID missionSetId, Principal principal) {
         if (principal == null) {
-            throw new IllegalStateException("인증된 사용자가 없습니다.");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증된 사용자가 없습니다.");
         }
-
         Long userId = userService.getUserIdByUsername(principal.getName());
         if (userId == null) {
-            throw new IllegalArgumentException("해당 사용자를 찾을 수 없습니다: " + principal.getName());
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED,
+                    "해당 사용자를 찾을 수 없습니다: " + principal.getName());
         }
-
-        return missionSetService.getOne(missionSetId, userId);
+        try {
+            return missionSetService.getOne(missionSetId, userId);
+        } catch (NoSuchElementException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
     }
 
 }

--- a/src/main/java/com/example/popin/domain/mission/controller/MissionSetController.java
+++ b/src/main/java/com/example/popin/domain/mission/controller/MissionSetController.java
@@ -5,6 +5,7 @@ import com.example.popin.domain.mission.service.MissionSetService;
 import com.example.popin.domain.user.UserService;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.util.List;
 
 @RestController
@@ -20,11 +21,17 @@ public class MissionSetController {
     }
 
     @GetMapping("/by-popup/{popupId}")
-    public List<MissionSetViewDto> byPopup(@PathVariable Long popupId, java.security.Principal principal) {
-        Long userId = 1L; //TODO: 실제 userid값 받아오도록 수정 필요
-        //if (principal != null) {
-        //    userId = userService.getUserIdByUsername(principal.getName());
-        //}
+    public List<MissionSetViewDto> byPopup(@PathVariable Long popupId, Principal principal) {
+        Long userId = null;
+
+        if (principal != null) {
+            userId = userService.getUserIdByUsername(principal.getName());
+        }
+
+        if (userId == null) {
+            throw new IllegalStateException("로그인한 사용자 정보를 찾을 수 없습니다.");
+        }
+
         return missionSetService.getByPopup(popupId, userId);
     }
 }

--- a/src/main/java/com/example/popin/domain/mission/controller/MissionSetController.java
+++ b/src/main/java/com/example/popin/domain/mission/controller/MissionSetController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/mission-sets")
@@ -20,18 +21,18 @@ public class MissionSetController {
         this.userService = userService;
     }
 
-    @GetMapping("/by-popup/{popupId}")
-    public List<MissionSetViewDto> byPopup(@PathVariable Long popupId, Principal principal) {
-        Long userId = null;
-
-        if (principal != null) {
-            userId = userService.getUserIdByUsername(principal.getName());
+    @GetMapping("/{missionSetId}")
+    public MissionSetViewDto byMissionSet(@PathVariable UUID missionSetId, Principal principal) {
+        if (principal == null) {
+            throw new IllegalStateException("인증된 사용자가 없습니다.");
         }
 
+        Long userId = userService.getUserIdByUsername(principal.getName());
         if (userId == null) {
-            throw new IllegalStateException("로그인한 사용자 정보를 찾을 수 없습니다.");
+            throw new IllegalArgumentException("해당 사용자를 찾을 수 없습니다: " + principal.getName());
         }
 
-        return missionSetService.getByPopup(popupId, userId);
+        return missionSetService.getOne(missionSetId, userId);
     }
+
 }

--- a/src/main/java/com/example/popin/domain/mission/dto/MissionSetViewDto.java
+++ b/src/main/java/com/example/popin/domain/mission/dto/MissionSetViewDto.java
@@ -1,18 +1,74 @@
 package com.example.popin.domain.mission.dto;
 
+import com.example.popin.domain.mission.entity.MissionSet;
+import com.example.popin.domain.mission.entity.UserMission;
+import com.example.popin.domain.mission.entity.UserMissionStatus;
+import com.example.popin.domain.mission.repository.UserMissionRepository;
 import lombok.Getter;
 import lombok.Setter;
-import java.util.List;
-import java.util.UUID;
+
+import java.util.*;
 
 @Getter @Setter
 public class MissionSetViewDto {
     private UUID missionSetId;
     private Long popupId;
-    private Integer requiredCount;   // 세트 클리어에 필요한 성공 수(없으면 null)
-    private int totalMissions;       // 미션 개수
-    private Long userId;
-    private long successCount;       // userId 있으면 채움
-    private boolean cleared;         // successCount >= requiredCount
+    private Integer requiredCount;
     private List<MissionSummaryDto> missions;
+    private int totalMissions;
+
+    private Long userId;
+    private Long successCount;
+    private Boolean cleared;
+
+    public static MissionSetViewDto of(MissionSet set, Long userId, UserMissionRepository userMissionRepository) {
+        MissionSetViewDto dto = new MissionSetViewDto();
+        dto.setMissionSetId(set.getId());
+        dto.setPopupId(set.getPopupId());
+        dto.setRequiredCount(set.getRequiredCount());
+
+        // 미션 목록 변환
+        List<MissionSummaryDto> missions = new ArrayList<>();
+        if (set.getMissions() != null) {
+            set.getMissions().forEach(m -> {
+                MissionSummaryDto ms = new MissionSummaryDto();
+                ms.setId(m.getId());
+                ms.setTitle(m.getTitle());
+                ms.setDescription(m.getDescription());
+                missions.add(ms);
+            });
+        }
+        dto.setMissions(missions);
+        dto.setTotalMissions(missions.size());
+
+        // 사용자 진행도 반영
+        if (userId != null) {
+            dto.setUserId(userId);
+
+            List<UserMission> ums = userMissionRepository.findByUser_IdAndMission_MissionSet_Id(userId, set.getId());
+
+            Map<UUID, UserMissionStatus> byMissionId = new HashMap<>();
+            long successCnt = 0L;
+
+            for (UserMission um : ums) {
+                UUID missionId = (um.getMission() != null ? um.getMission().getId() : null);
+                if (missionId != null) {
+                    byMissionId.put(missionId, um.getStatus());
+                }
+                if (um.getStatus() == UserMissionStatus.SUCCESS) {
+                    successCnt++;
+                }
+            }
+
+            for (MissionSummaryDto ms : missions) {
+                ms.setUserStatus(byMissionId.get(ms.getId()));
+            }
+
+            dto.setSuccessCount(successCnt);
+            int req = (dto.getRequiredCount() == null ? 0 : dto.getRequiredCount());
+            dto.setCleared(successCnt >= req);
+        }
+
+        return dto;
+    }
 }

--- a/src/main/java/com/example/popin/domain/mission/service/MissionSetService.java
+++ b/src/main/java/com/example/popin/domain/mission/service/MissionSetService.java
@@ -107,6 +107,15 @@ public class MissionSetService {
         return result;
     }
 
+    /** 특정 미션셋 목록 조회 **/
+    public MissionSetViewDto getOne(UUID missionSetId, Long userId) {
+        MissionSet ms = missionSetRepository.findById(missionSetId)
+                .orElseThrow(() -> new IllegalArgumentException("MissionSet not found"));
+        return MissionSetViewDto.of(ms, userId, userMissionRepository);
+    }
+
+
+
     @Transactional(readOnly = true)
     public List<MissionSetViewDto> getByPopup(Long popupId) {
         return getByPopup(popupId, null);

--- a/src/main/java/com/example/popin/domain/reward/controller/RewardController.java
+++ b/src/main/java/com/example/popin/domain/reward/controller/RewardController.java
@@ -112,10 +112,16 @@ public class RewardController {
     }
 
     private Long resolveUserId(Principal principal) {
-        if (principal != null) {
-            Long id = userService.getUserIdByUsername(principal.getName());
-            if (id != null) return id;
+        if (principal == null) {
+            throw new IllegalStateException("로그인 정보가 없습니다.");
         }
-        return 1L; // TODO: 개발용 fallback
+
+        Long id = userService.getUserIdByUsername(principal.getName());
+        if (id == null) {
+            throw new IllegalStateException("사용자 ID를 찾을 수 없습니다: " + principal.getName());
+        }
+
+        return id;
     }
+
 }

--- a/src/main/java/com/example/popin/domain/reward/controller/RewardController.java
+++ b/src/main/java/com/example/popin/domain/reward/controller/RewardController.java
@@ -63,18 +63,33 @@ public class RewardController {
 
     // 수령 (PIN 입력)
     @PostMapping("/redeem")
-    public ResponseEntity<RedeemResponseDto> redeem(@RequestBody @Valid RedeemRequestDto req,
-                                                    Principal principal) {
+    public ResponseEntity<RedeemResponseDto> redeem(
+            @RequestBody @Valid RedeemRequestDto req,
+            Principal principal
+    ) {
         Long userId = resolveUserId(principal);
-        var rw = rewardService.redeem(req.getMissionSetId(), userId, req.getStaffPin());
-        return ResponseEntity.ok(
-                RedeemResponseDto.builder()
-                        .ok(true)
-                        .status(rw.getStatus().name())
-                        .redeemedAt(rw.getRedeemedAt())
-                        .build()
-        );
+        try {
+            var rw = rewardService.redeem(req.getMissionSetId(), userId, req.getStaffPin());
+            return ResponseEntity.ok(
+                    RedeemResponseDto.builder()
+                            .ok(true)
+                            .status(rw.getStatus().name())
+                            .redeemedAt(rw.getRedeemedAt())
+                            .build()
+            );
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            // 400으로 내려주고, 메시지를 'PIN 인증 실패'로 변환
+            return ResponseEntity
+                    .badRequest()
+                    .body(RedeemResponseDto.builder()
+                            .ok(false)
+                            .status("FAILED")
+                            .error("PIN 인증 실패")
+                            .build()
+                    );
+        }
     }
+
 
     // 내 리워드 조회 (이미 발급 받았는지 확인)
     @GetMapping("/my/{missionSetId}")

--- a/src/main/java/com/example/popin/domain/reward/dto/response/RedeemResponseDto.java
+++ b/src/main/java/com/example/popin/domain/reward/dto/response/RedeemResponseDto.java
@@ -9,4 +9,5 @@ public class RedeemResponseDto {
     private boolean ok;
     private String status;            // REDEEMED
     private LocalDateTime redeemedAt; // 수령 시각
+    private String error;
 }

--- a/src/main/java/com/example/popin/domain/reward/entity/RewardOption.java
+++ b/src/main/java/com/example/popin/domain/reward/entity/RewardOption.java
@@ -23,14 +23,17 @@ public class RewardOption extends BaseEntity {
     @Column(nullable = false)
     private int total;
 
+    //발급된 개수
     @Column(nullable = false)
     private int issued;
 
     @Version
     private long version;
 
+    //남은 재고
     public int getRemaining() { return Math.max(0, total - issued); }
 
+    //제고 초과 방지
     public void consumeOne() {
         if (getRemaining() <= 0) throw new IllegalStateException("OUT_OF_STOCK");
         issued++;

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -143,10 +143,11 @@ class SimpleApiService {
         return await this.get(url);
     }
 
-    async getMissionSetsByPopup(popupId) {
-        const url = `/mission-sets/by-popup/${encodeURIComponent(popupId)}`;
+    async getMissionSet(missionSetId) {
+        const url = `/mission-sets/${encodeURIComponent(missionSetId)}`;
         return this.get(url);
     }
+
 
     async submitMissionAnswer(missionId, answer) {
         return this.post(`/user-missions/${encodeURIComponent(missionId)}/submit-answer`, { answer });

--- a/src/main/resources/static/js/reward.js
+++ b/src/main/resources/static/js/reward.js
@@ -1,4 +1,3 @@
-// reward.js
 (function () {
     // 리워드 룰렛 UI 열기
     async function openRewardRoulette(missionSetId) {


### PR DESCRIPTION
## 📌 Summary
- resolve: #21 
- Related Jira: POP-6

## ✨ Description
- missionSet 기반으로 접속 하도록 수정
- 키 입력하면 리워드 수령 완료 하도록 기능 추가

## 📸 Screenshot
|기능|스크린샷|
|:--:|:--:|
|접속 url 수정|<img width="659" height="209" alt="image" src="https://github.com/user-attachments/assets/a78eb078-492c-4c9a-b5dd-025209dc3427" />|

## 🗒️ Review Point
```
mission set 기반으로 바꾼 이유는 popup id로 url 유추 해서 들어오는 케이스가 발생하지 않도록 uuid로 만든  mission set 으로 변경했습니다
```

## ✅ CheckList
- [x] 재고 관리 정상적으로 되는지 확인
- [x] missionSetId로 정상 접속 되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Mission board shows reward status (claimable, claimed, or mission complete) and supports staff PIN redemption via a new modal.
  - Mission modal refreshed with inline content and streamlined interactions; board auto-refreshes after submissions.

- Refactor
  - Pages and client calls now fetch a single mission set by missionSetId.

- Bug Fixes
  - Reward redemption and mission endpoints require authenticated users and return clearer error responses on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->