### PR TITLE
feat #POP-93: 카테고리 수정/조회기능 추가

### DIFF
--- a/src/main/java/com/snow/popin/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/snow/popin/domain/category/controller/CategoryController.java
@@ -2,6 +2,7 @@ package com.snow.popin.domain.category.controller;
 
 import com.snow.popin.domain.category.dto.CategoryResponseDto;
 import com.snow.popin.domain.category.service.CategoryService;
+import com.snow.popin.global.util.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +15,7 @@ import java.util.List;
 public class CategoryController {
 
     private final CategoryService categoryService;
+    private final UserUtil userUtil;
 
     // 전체 카테고리 목록 조회
     @GetMapping
@@ -22,7 +24,21 @@ public class CategoryController {
         return ResponseEntity.ok(categories);
     }
 
-    // TODO: 사용자 관심 카테고리 조회 (로그인 필요)
+    // 사용자 관심 카테고리 조회
+    @GetMapping("/me")
+    public ResponseEntity<List<CategoryResponseDto>> getMyCategories() {
+        Long userId = userUtil.getCurrentUserId();
+        List<CategoryResponseDto> categories = categoryService.getUserCategories(userId);
+        return ResponseEntity.ok(categories);
+    }
 
-    // TODO: 사용자 관심 카테고리 업데이트 (로그인 필요)
+    // 사용자 관심 카테고리 업데이트
+    @PutMapping("/me")
+    public ResponseEntity<List<CategoryResponseDto>> updateMyCategories(
+            @RequestBody List<String> categoryNames
+    ) {
+        Long userId = userUtil.getCurrentUserId();
+        List<CategoryResponseDto> updated = categoryService.updateUserCategories(userId, categoryNames);
+        return ResponseEntity.ok(updated);
+    }
 }

--- a/src/main/java/com/snow/popin/domain/category/entity/UserInterest.java
+++ b/src/main/java/com/snow/popin/domain/category/entity/UserInterest.java
@@ -1,0 +1,38 @@
+package com.snow.popin.domain.category.entity;
+
+import com.snow.popin.domain.category.entity.Category;
+import com.snow.popin.domain.user.entity.User;
+import com.snow.popin.global.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "user_interests",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_interest",
+                columnNames = {"user_id", "category_id"}
+        ))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserInterest extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    public UserInterest(User user, Category category) {
+        this.user = user;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/snow/popin/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/snow/popin/domain/category/repository/CategoryRepository.java
@@ -6,10 +6,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    @Query("SELECT c FROM Category c  ORDER BY c.id ASC")
-    List<Category> findAllOrderById();
+    java.util.List<Category> findAllByOrderByIdAsc();
+
+    Set<Category> findByNameIn(List<String> names);
 }

--- a/src/main/java/com/snow/popin/domain/category/repository/UserInterestRepository.java
+++ b/src/main/java/com/snow/popin/domain/category/repository/UserInterestRepository.java
@@ -1,0 +1,11 @@
+package com.snow.popin.domain.category.repository;
+
+import com.snow.popin.domain.category.entity.UserInterest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserInterestRepository extends JpaRepository<UserInterest, Long> {
+    List<UserInterest> findByUser_Id(Long userId);
+    void deleteByUser_Id(Long userId);
+}

--- a/src/main/java/com/snow/popin/domain/category/service/CategoryService.java
+++ b/src/main/java/com/snow/popin/domain/category/service/CategoryService.java
@@ -3,29 +3,67 @@ package com.snow.popin.domain.category.service;
 import com.snow.popin.domain.category.dto.CategoryResponseDto;
 import com.snow.popin.domain.category.entity.Category;
 import com.snow.popin.domain.category.repository.CategoryRepository;
+import com.snow.popin.domain.user.entity.User;
+import com.snow.popin.domain.user.repository.UserRepository;
+import com.snow.popin.global.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
-    // TODO: UserService 추가 필요 (사용자 관심 카테고리 관리)
+    private final UserRepository userRepository;
 
     // 전체 카테고리 목록 조회
+    @Transactional(readOnly = true)
     public List<CategoryResponseDto> getAllCategories() {
-        List<Category> categories = categoryRepository.findAllOrderById();
+        List<Category> categories = categoryRepository.findAllByOrderByIdAsc();
         return categories.stream()
                 .map(CategoryResponseDto::from)
                 .collect(Collectors.toList());
     }
 
+    // 사용자 관심 카테고리 조회
+    @Transactional(readOnly = true)
+    public List<CategoryResponseDto> getUserCategories(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException.UserNotFound(userId));
+
+        return user.getInterests().stream()
+                .map(interest -> CategoryResponseDto.from(interest.getCategory()))
+                .collect(Collectors.toList());
+    }
+
+    // 사용자 관심 카테고리 업데이트
+    @Transactional
+    public List<CategoryResponseDto> updateUserCategories(Long userId, List<String> categoryNames) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException.UserNotFound(userId));
+
+        // 기존 관심사 전부 삭제 (orphanRemoval 보장)
+        user.getInterests().clear();
+        userRepository.flush(); // 즉시 DB 반영 → 중복 insert 방지
+
+        // 새로운 카테고리 찾기
+        Set<Category> categories = categoryRepository.findByNameIn(categoryNames);
+
+        // User 엔티티 메서드로 관심사 재설정
+        user.updateInterests(List.copyOf(categories));
+
+        // 저장
+        userRepository.save(user);
+
+        return categories.stream()
+                .map(CategoryResponseDto::from)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/snow/popin/domain/user/entity/User.java
+++ b/src/main/java/com/snow/popin/domain/user/entity/User.java
@@ -1,11 +1,15 @@
 package com.snow.popin.domain.user.entity;
 
 import com.snow.popin.domain.auth.constant.AuthProvider;
+import com.snow.popin.domain.category.entity.Category;
+import com.snow.popin.domain.category.entity.UserInterest;
 import com.snow.popin.domain.user.constant.Role;
 import com.snow.popin.global.common.BaseEntity;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "user")
@@ -37,6 +41,10 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserInterest> interests = new ArrayList<>();
+
+
     @Builder
     public User(String email, String password, String name, String nickname,
                 String phone, AuthProvider authProvider, Role role) {
@@ -54,6 +62,13 @@ public class User extends BaseEntity {
         this.name = name;
         this.nickname = nickname;
         this.phone = phone;
+    }
+
+    public void updateInterests(List<Category> newCategories) {
+        this.interests.clear();
+        for (Category category : newCategories) {
+            this.interests.add(new UserInterest(this, category));
+        }
     }
 
     public void changePassword(String newPassword) {


### PR DESCRIPTION
## 📌 Summary
- resolve: #65 
- Related Jira: POP-93

## ✨ Description
- 유저 카테고리 수정 기능 추가
- 카테고리 조회 기능 추가

## 📸 Screenshot
<!-- UI 변화가 없다면 지워주세요 -->
|기능|스크린샷|
|:--:|:--:|
|카테고리 수정 기능|<img width="497" height="969" alt="image" src="https://github.com/user-attachments/assets/83d012dd-8b82-4451-a7dc-a34a26921b87" />|

## 🗒️ Review Point
```
erd에 있는데로 USER_INTERESTS 추가 해서 카테고리와 연결했습니다
```

## ✅ CheckList
- [x] 유저 카테고리 조회
- [x] 유저 카테고리 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Manage your interest categories on My Page with clickable buttons; selections are saved and restored automatically.
  - Missions are displayed with a consistent card layout, showing images or placeholders, and separated into active (“이어하기”) and completed (“다시보기”).

- Refactor
  - Unified mission card rendering to reduce duplication and improve consistency.

- Bug Fixes
  - Improved error handling when loading or updating categories; clearer messages are shown to users and operations are more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->