### PR TITLE
feat #POP-89

### DIFF
--- a/src/main/java/com/snow/popin/domain/roleupgrade/controller/RoleUpgradeUserApiController.java
+++ b/src/main/java/com/snow/popin/domain/roleupgrade/controller/RoleUpgradeUserApiController.java
@@ -1,0 +1,37 @@
+package com.snow.popin.domain.roleupgrade.controller;
+
+import com.snow.popin.domain.roleupgrade.dto.CreateRoleUpgradeRequest;
+import com.snow.popin.domain.roleupgrade.service.RoleUpgradeService;
+import com.snow.popin.global.util.UserUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/role-upgrade")
+@RequiredArgsConstructor
+public class RoleUpgradeUserApiController {
+
+    private final RoleUpgradeService roleService;
+    private final UserUtil userUtil;
+
+    @PostMapping("/request")
+    public ResponseEntity<?> createRequest(
+            @Valid @RequestPart("request") CreateRoleUpgradeRequest req,
+            @RequestPart(value = "documents", required = false) List<MultipartFile> files
+    ) {
+
+        String userEmail = userUtil.getCurrentUserEmail();
+        Long reqId = roleService.createRoleUpgradeRequest(userEmail, req);
+
+        return ResponseEntity.ok(Map.of(
+                "message", "역할 승격 요청이 성공적으로 제출되었습니다.",
+                "requestId", reqId
+        ));
+    }
+}

--- a/src/main/java/com/snow/popin/domain/roleupgrade/dto/AdminUpdateRequest.java
+++ b/src/main/java/com/snow/popin/domain/roleupgrade/dto/AdminUpdateRequest.java
@@ -1,0 +1,39 @@
+package com.snow.popin.domain.roleupgrade.dto;
+
+import com.snow.popin.domain.roleupgrade.entity.ApprovalStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+public class AdminUpdateRequest {
+
+    @NotBlank(message = "승인 상태는 필수입니다")
+    private Boolean approve;
+
+    private String rejectReason; // 반려 시에만 필요
+
+    @Builder
+    public AdminUpdateRequest(Boolean approve, String rejectReason) {
+        this.approve = approve;
+        this.rejectReason = rejectReason;
+
+    }
+
+    public boolean isApprove(){
+        return approve != null && approve;
+    }
+
+    // 반려 시 반려 사유 필수
+    @AssertTrue(message = "반려 시 반려 사유를 입력해주세요.")
+    private boolean isRejectReasonValid(){
+        if (approve != null && !approve){
+            return rejectReason != null && !rejectReason.trim().isEmpty();
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/snow/popin/domain/roleupgrade/dto/CreateRoleUpgradeRequest.java
+++ b/src/main/java/com/snow/popin/domain/roleupgrade/dto/CreateRoleUpgradeRequest.java
@@ -1,0 +1,24 @@
+package com.snow.popin.domain.roleupgrade.dto;
+
+import com.snow.popin.domain.user.constant.Role;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateRoleUpgradeRequest {
+
+    @NotNull(message = "요청 역할은 필수입니다")
+    private Role requestedRole;
+
+    // ERD의 payload JSON 컬럼에 맞게 String으로 받기
+    private String payload;
+
+    @Builder
+    public CreateRoleUpgradeRequest(Role requestedRole, String payload) {
+        this.requestedRole = requestedRole;
+        this.payload = payload;
+    }
+}

--- a/src/main/java/com/snow/popin/domain/roleupgrade/dto/DocumentResponse.java
+++ b/src/main/java/com/snow/popin/domain/roleupgrade/dto/DocumentResponse.java
@@ -1,0 +1,23 @@
+package com.snow.popin.domain.roleupgrade.dto;
+
+import com.snow.popin.domain.roleupgrade.entity.DocumentType;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+public class DocumentResponse {
+
+    private Long id;
+    private DocumentType docType;
+    private String businessNumber;
+    private String fileUrl;
+
+    @Builder
+    public DocumentResponse(Long id, DocumentType docType, String businessNumber,
+                            String fileUrl) {
+        this.id = id;
+        this.docType = docType;
+        this.businessNumber = businessNumber;
+        this.fileUrl = fileUrl;
+    }
+}

--- a/src/main/java/com/snow/popin/domain/roleupgrade/dto/DocumentUploadRequest.java
+++ b/src/main/java/com/snow/popin/domain/roleupgrade/dto/DocumentUploadRequest.java
@@ -1,0 +1,28 @@
+package com.snow.popin.domain.roleupgrade.dto;
+
+import com.snow.popin.domain.roleupgrade.entity.DocumentType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+public class DocumentUploadRequest {
+
+
+    private DocumentType docType;
+
+    private String businessNumber; // 사업자등록증인 경우에만
+
+    private String fileUrl;
+
+    @Builder
+    public DocumentUploadRequest(DocumentType docType, String businessNumber, String fileUrl) {
+        this.docType = docType;
+        this.businessNumber = businessNumber;
+        this.fileUrl = fileUrl;
+    }
+
+}

--- a/src/main/java/com/snow/popin/domain/roleupgrade/dto/RoleUpgradeResponse.java
+++ b/src/main/java/com/snow/popin/domain/roleupgrade/dto/RoleUpgradeResponse.java
@@ -1,0 +1,60 @@
+package com.snow.popin.domain.roleupgrade.dto;
+
+import com.snow.popin.domain.roleupgrade.entity.ApprovalStatus;
+import com.snow.popin.domain.roleupgrade.entity.RoleUpgrade;
+import com.snow.popin.domain.user.constant.Role;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+public class RoleUpgradeResponse {
+
+    private Long id;
+    private String email;
+    private Role requestedRole;
+    private ApprovalStatus status;
+    private String rejectReason;
+    private String payload; // JSON 문자열
+    private List<DocumentResponse> documents;
+
+
+    @Builder
+    public RoleUpgradeResponse(Long id, String email, Role requestedRole, ApprovalStatus status,
+                               String rejectReason, String payload, List<DocumentResponse> documents) {
+        this.id = id;
+        this.email = email;
+        this.requestedRole = requestedRole;
+        this.status = status;
+        this.rejectReason = rejectReason;
+        this.payload = payload;
+        this.documents = documents;
+    }
+
+
+    // RoleUpgrade 엔티티를 Response DTO로 변환
+    // 순환 참조 주의
+    public static RoleUpgradeResponse from(RoleUpgrade roleUpgrade) {
+        List<DocumentResponse> documents = roleUpgrade.getDocuments().stream()
+                .map(doc -> DocumentResponse.builder()
+                        .id(doc.getId())
+                        .docType(doc.getDocType())
+                        .businessNumber(doc.getBusinessNumber())
+                        .fileUrl(doc.getFileUrl())
+                        .build()
+                ).collect(Collectors.toList());
+
+        return RoleUpgradeResponse.builder()
+                .id(roleUpgrade.getId())
+                .email(roleUpgrade.getEmail())
+                .requestedRole(roleUpgrade.getRequestedRole())
+                .status(roleUpgrade.getStatus())
+                .rejectReason(roleUpgrade.getRejectReason())
+                .payload(roleUpgrade.getPayload())
+                .documents(documents)
+                .build();
+    }
+}

--- a/src/main/java/com/snow/popin/domain/roleupgrade/entity/ApprovalStatus.java
+++ b/src/main/java/com/snow/popin/domain/roleupgrade/entity/ApprovalStatus.java
@@ -1,0 +1,7 @@
+package com.snow.popin.domain.roleupgrade.entity;
+
+public enum ApprovalStatus {
+    PENDING,    // 승인 대기
+    APPROVED,   // 승인됨
+    REJECTED    // 반려됨
+}

--- a/src/main/java/com/snow/popin/domain/roleupgrade/entity/DocumentType.java
+++ b/src/main/java/com/snow/popin/domain/roleupgrade/entity/DocumentType.java
@@ -1,0 +1,7 @@
+package com.snow.popin.domain.roleupgrade.entity;
+
+public enum DocumentType {
+    BUSINESS_LICENSE, // 사업자등록증
+    REAL_ESTATE,      // 부동산 관련 서류
+    ETC               // 기타
+}

--- a/src/main/java/com/snow/popin/domain/roleupgrade/entity/RoleUpgrade.java
+++ b/src/main/java/com/snow/popin/domain/roleupgrade/entity/RoleUpgrade.java
@@ -1,0 +1,80 @@
+package com.snow.popin.domain.roleupgrade.entity;
+
+import com.snow.popin.domain.user.constant.Role;
+import com.snow.popin.global.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "role_upgrades")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoleUpgrade extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email; // 신청자 이메일 (JWT에서 추출)
+
+    @Column(name = "requested_role", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role requestedRole; // 요청하는 역할 (PROVIDER/HOST)
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ApprovalStatus status = ApprovalStatus.PENDING; // 승인 상태, default : 승인 대기
+
+    @Column(name = "reject_reason")
+    private String rejectReason; // 반려 사유
+
+    @Column(columnDefinition = "JSON")
+    private String payload; // 회사명, 사업자등록번호, 추가 작성사항 등을 JSON으로 저장
+
+    @OneToMany(mappedBy = "roleUpgrade", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoleUpgradeDocument> documents = new ArrayList<>();
+
+    @Builder
+    public RoleUpgrade(String email, Role requestedRole, String payload) {
+        this.email = email;
+        this.requestedRole = requestedRole;
+        this.payload = payload;
+    }
+
+    // 비즈니스 로직 메소드
+    public void approve(){
+        this.status = ApprovalStatus.APPROVED;
+        this.rejectReason = null;
+    }
+
+    public void reject(String rejectReason){
+        this.status = ApprovalStatus.REJECTED;
+        this.rejectReason = rejectReason;
+    }
+
+    public void addDocument(RoleUpgradeDocument document){
+        this.documents.add(document);
+        document.setRoleUpgrade(this);
+    }
+
+    // 상태 체크 메소드들
+    public boolean isPending() {
+        return this.status == ApprovalStatus.PENDING;
+    }
+
+    public boolean isApproved() {
+        return this.status == ApprovalStatus.APPROVED;
+    }
+
+    public boolean isRejected() {
+        return this.status == ApprovalStatus.REJECTED;
+    }
+
+}

--- a/src/main/java/com/snow/popin/domain/roleupgrade/entity/RoleUpgradeDocument.java
+++ b/src/main/java/com/snow/popin/domain/roleupgrade/entity/RoleUpgradeDocument.java
@@ -1,0 +1,50 @@
+package com.snow.popin.domain.roleupgrade.entity;
+
+import com.snow.popin.global.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name ="role_upgrade_documents")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoleUpgradeDocument extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_upgrade_id", nullable = false)
+    private RoleUpgrade roleUpgrade;
+
+    @Column(name = "doc_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private DocumentType docType;
+
+    @Column(name = "business_number")
+    private String businessNumber; // 사업자등록번호
+
+    @Column(name = "file_url", nullable = false)
+    private String fileUrl; // 파일 저장 경로
+
+    @Builder
+    public RoleUpgradeDocument(RoleUpgrade roleUpgrade, DocumentType docType,
+                               String businessNumber, String fileUrl) {
+        this.roleUpgrade = roleUpgrade;
+        this.docType = docType;
+        this.businessNumber = businessNumber;
+        this.fileUrl = fileUrl;
+    }
+
+    // 연관관계 편의 메소드
+    protected void setRoleUpgrade(RoleUpgrade roleUpgrade) {
+        this.roleUpgrade = roleUpgrade;
+    }
+
+
+}

--- a/src/main/java/com/snow/popin/domain/roleupgrade/repository/RoleUpgradeRepository.java
+++ b/src/main/java/com/snow/popin/domain/roleupgrade/repository/RoleUpgradeRepository.java
@@ -1,0 +1,49 @@
+package com.snow.popin.domain.roleupgrade.repository;
+
+import com.snow.popin.domain.roleupgrade.entity.ApprovalStatus;
+import com.snow.popin.domain.roleupgrade.entity.RoleUpgrade;
+import com.snow.popin.domain.user.constant.Role;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RoleUpgradeRepository extends JpaRepository<RoleUpgrade, Long> {
+
+    // 특정 이메일의 승인 요청 목록 조회
+    List<RoleUpgrade> findByEmailOrderByCreatedAtDesc(String email);
+
+    // 특정 이메일의 특정 역할에 대한 대기중인 요청 확인
+    Optional<RoleUpgrade> findByEmailAndRequestedRoleAndStatus(String email, Role requestedRole, ApprovalStatus status);
+
+    // 특정 이메일의 대기중인 요청이 있는지 확인
+    boolean existsByEmailAndStatus(String email, ApprovalStatus status);
+
+    // 관리자용 : 모든 승인 요청 페이징 조회
+    Page<RoleUpgrade> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    // 관리자용: 상태별 승인 요청 페이징 조회
+    Page<RoleUpgrade> findByStatusOrderByCreatedAtDesc(ApprovalStatus status, Pageable pageable);
+
+    // 관리자용: 요청 역할별 승인 요청 페이징 조회
+    Page<RoleUpgrade> findByRequestedRoleOrderByCreatedAtDesc(Role requestedRole, Pageable pageable);
+
+    // 관리자용: 상태와 역할 모두로 필터링
+    Page<RoleUpgrade> findByStatusAndRequestedRoleOrderByCreatedAtDesc(
+            ApprovalStatus status, Role requestedRole, Pageable pageable);
+
+    // 특정 이메일의 최신 요청 조회
+    Optional<RoleUpgrade> findFirstByEmailOrderByCreatedAtDesc(String email);
+
+    // 대기중인 요청 개수 조회 (관리자용)
+    long countByStatus(ApprovalStatus status);
+
+    // 특정 기간의 승인 요청 조회 (통계용)
+    @Query("SELECT r FROM RoleUpgrade r WHERE r.createdAt >= :startDate AND r.createdAt <= :endDate")
+    List<RoleUpgrade> findByCreatedAtBetween(@Param("startDate") java.time.LocalDateTime startDate,
+                                             @Param("endDate") java.time.LocalDateTime endDate);
+}

--- a/src/main/java/com/snow/popin/domain/roleupgrade/service/RoleUpgradeService.java
+++ b/src/main/java/com/snow/popin/domain/roleupgrade/service/RoleUpgradeService.java
@@ -1,0 +1,272 @@
+package com.snow.popin.domain.roleupgrade.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snow.popin.domain.roleupgrade.dto.*;
+import com.snow.popin.domain.roleupgrade.entity.ApprovalStatus;
+import com.snow.popin.domain.roleupgrade.entity.DocumentType;
+import com.snow.popin.domain.roleupgrade.entity.RoleUpgrade;
+import com.snow.popin.domain.roleupgrade.entity.RoleUpgradeDocument;
+import com.snow.popin.domain.roleupgrade.repository.RoleUpgradeRepository;
+import com.snow.popin.domain.user.constant.Role;
+import com.snow.popin.domain.user.entity.User;
+import com.snow.popin.domain.user.repository.UserRepository;
+import com.snow.popin.global.constant.ErrorCode;
+import com.snow.popin.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class RoleUpgradeService {
+
+    private final RoleUpgradeRepository roleRepo;
+    private final UserRepository userRepo;
+    private final ObjectMapper objMapper;
+
+
+    // 역할 승격 요청 생성
+    @Transactional
+    public Long createRoleUpgradeRequest(String email, CreateRoleUpgradeRequest  req){
+
+        validateNoDuplicateRequest(email);
+
+        try {
+            String payloadJson = objMapper.writeValueAsString(req.getPayload());
+
+            RoleUpgrade roleUpgrade = RoleUpgrade.builder()
+                    .email(email)
+                    .requestedRole(req.getRequestedRole())
+                    .payload(payloadJson)
+                    .build();
+
+            RoleUpgrade saved = roleRepo.save(roleUpgrade);
+            log.info("역할 승격 요청이 생성되었습니다. ID: {}, Email: {}", saved.getId(), email);
+
+            return saved.getId();
+
+        } catch (Exception e) {
+            log.error("역할 승격 요청 생성 실패: {}", e.getMessage());
+            throw new GeneralException(ErrorCode.INTERNAL_ERROR);
+        }
+    }
+
+    // 역할 승격 요청 생성 + file
+    @Transactional
+    public Long createRoleUpgradeRequestWithDocuments(String email, CreateRoleUpgradeRequest req, List<MultipartFile> files) {
+        validateNoDuplicateRequest(email);
+
+        try {
+            // 1. 기본 요청 생성
+            RoleUpgrade roleUpgrade = RoleUpgrade.builder()
+                    .email(email)
+                    .requestedRole(req.getRequestedRole())
+                    .payload(req.getPayload())
+                    .build();
+
+            RoleUpgrade saved = roleRepo.save(roleUpgrade);
+
+            // 2. 파일이 있는 경우에만 문서 처리
+            if (files != null && !files.isEmpty()) {
+                // 역할에 따른 DocumentType 결정
+                DocumentType docType = determineDocTypeByRole(req.getRequestedRole());
+
+                for (MultipartFile file : files) {
+                    if (!file.isEmpty()) {
+                        String fileUrl = saveFile(file);
+
+                        RoleUpgradeDocument document = RoleUpgradeDocument.builder()
+                                .roleUpgrade(saved)
+                                .docType(docType)
+                                .fileUrl(fileUrl)
+                                .build();
+
+                        saved.addDocument(document);
+                    }
+                }
+            }
+
+            log.info("역할 승격 요청 생성 완료. ID: {}, Email: {}, Role: {}, 첨부파일 수: {}",
+                    saved.getId(), email, req.getRequestedRole(), files != null ? files.size() : 0);
+
+            return saved.getId();
+
+        } catch (Exception e) {
+            log.error("역할 승격 요청 생성 실패: {}", e.getMessage());
+            throw new GeneralException(ErrorCode.INTERNAL_ERROR);
+        }
+    }
+
+    // 역할에 따른 DocumentType 결정
+    private DocumentType determineDocTypeByRole(Role requestedRole) {
+        switch (requestedRole) {
+            case HOST:
+                return DocumentType.BUSINESS_LICENSE; // 사업자등록증
+            case PROVIDER:
+                return DocumentType.REAL_ESTATE;      // 부동산 관련 서류
+            default:
+                return DocumentType.ETC;              // 기타
+        }
+    }
+
+    // 내 역할 승격 요청 목록 조회
+    public List<RoleUpgradeResponse> getMyRoleUpgradeRequests(String email){
+
+        List<RoleUpgrade> reqs = roleRepo.findByEmailOrderByCreatedAtDesc(email);
+
+        return reqs.stream()
+                .map(RoleUpgradeResponse::from)
+                .collect(Collectors.toList());
+
+    }
+
+    // 역할 승격 요청 상세 조회
+    public RoleUpgradeResponse getRoleUpgradeRequest(Long id, String email){
+        RoleUpgrade roleUpgrade = roleRepo.findById(id)
+                .orElseThrow(() -> new GeneralException(ErrorCode.ROLE_UPGRADE_REQUEST_NOT_FOUND));
+
+        // 본인의 요청만 조회 (관리자는 별도 메소드 사용)
+        if (!roleUpgrade.getEmail().equals(email)){
+            throw new GeneralException(ErrorCode.ACCESS_DENIED);
+        }
+
+        return RoleUpgradeResponse.from(roleUpgrade);
+    }
+
+    // 문서 첨부
+    @Transactional
+    public void attachDocument(Long upgradeId, String email, DocumentUploadRequest req){
+        RoleUpgrade roleUpgrade = findRoleUpgradeById(upgradeId);
+        // 본인의 요청인지 확인
+        validateOwnership(roleUpgrade, email);
+        // 대기중인 요청에만 문서 첨부 가능
+        validatePendingStatus(roleUpgrade);
+
+        // 파일 저장 로직 (실제 구현에서는 파일 저장 서비스 사용)
+        // String fileUrl = saveFile(request.getFileUrl());
+        String fileUrl = "fileUrl";
+
+        RoleUpgradeDocument document = RoleUpgradeDocument.builder()
+                .roleUpgrade(roleUpgrade)
+                .docType(req.getDocType())
+                .businessNumber(req.getBusinessNumber())
+                .fileUrl(fileUrl)
+                .build();
+
+        roleUpgrade.addDocument(document);
+
+        log.info("문서가 첨부되었습니다. RequestId: {}, DocType: {}", upgradeId, req.getDocType());
+
+    }
+
+
+    // 대기중인 요청 개수 조회 (관리자용)
+    public long getPendingRequestCount(){
+        return roleRepo.countByStatus(ApprovalStatus.PENDING);
+    }
+
+    // 관리자용: 모든 역할 승격 요청 페이징 조회
+    public Page<RoleUpgradeResponse> getAllRoleUpgradeRequests(Pageable pageable){
+
+        Page<RoleUpgrade> reqs = roleRepo.findAllByOrderByCreatedAtDesc(pageable);
+        return reqs.map(RoleUpgradeResponse::from);
+
+    }
+
+    // 관리자용: 상태별 역할 승격 요청 조회
+    public Page<RoleUpgradeResponse> getRoleUpgradeRequestsByStatus(ApprovalStatus status, Pageable pageable){
+
+        Page<RoleUpgrade> reqs = roleRepo.findByStatusOrderByCreatedAtDesc(status, pageable);
+        return reqs.map(RoleUpgradeResponse::from);
+
+    }
+
+    // 관리자용: 역할 승격 요청 처리 (승인/반려)
+    @Transactional
+    public void processRoleUpgradeRequest(Long id, AdminUpdateRequest req){
+
+        RoleUpgrade roleUpgrade = roleRepo.findById(id)
+                .orElseThrow(() -> new GeneralException(ErrorCode.ROLE_UPGRADE_REQUEST_NOT_FOUND));
+
+        // 대기중인 요청만 처리 가능
+        validatePendingStatus(roleUpgrade);
+
+        if (req.isApprove()){
+            // 승인 처리
+            roleUpgrade.approve();
+
+            // 사용자 역할 업데이트
+            User user = userRepo.findByEmail(roleUpgrade.getEmail())
+                    .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
+
+            user.updateRole(roleUpgrade.getRequestedRole());
+
+            log.info("역할 승격이 승인되었습니다. ID: {}, Email: {}, New Role: {}",
+                    id, roleUpgrade.getEmail(), roleUpgrade.getRequestedRole());
+
+        } else {
+            // 반려처리
+            roleUpgrade.reject(req.getRejectReason());
+
+            log.info("역할 승격이 반려되었습니다. ID: {}, Reason: {}", id, req.getRejectReason());
+
+        }
+    }
+
+
+    // 공통 로직들
+    // 이미 대기중인 요청이 있는지 확인
+    private void validateNoDuplicateRequest(String email){
+        if (roleRepo.existsByEmailAndStatus(email, ApprovalStatus.PENDING)){
+            throw new GeneralException(ErrorCode.DUPLICATE_ROLE_UPGRADE_REQUEST);
+        }
+    }
+
+    private void validateOwnership(RoleUpgrade roleUpgrade, String email){
+        if (!roleUpgrade.getEmail().equals(email)){
+            throw new GeneralException(ErrorCode.ACCESS_DENIED);
+        }
+    }
+
+    // 본인의 요청인지 확인
+    private RoleUpgrade findRoleUpgradeById(Long id){
+        return roleRepo.findById(id)
+                .orElseThrow(() -> new GeneralException(ErrorCode.ROLE_UPGRADE_REQUEST_NOT_FOUND));
+    }
+
+    // // 대기중인 요청에만 문서 첨부 가능
+    private void validatePendingStatus(RoleUpgrade roleUpgrade) {
+        if (!roleUpgrade.isPending()) {
+            throw new GeneralException(ErrorCode.INVALID_REQUEST_STATUS);
+        }
+    }
+
+    // 파일 저장 (실제 구현에서는 파일 저장 서비스로 분리)
+    private String saveFile(MultipartFile file){
+        try{
+
+            // 실제로는 AWS S3, 로컬 저장소 등을 사용
+            String fileName = System.currentTimeMillis() + "_" + file.getOriginalFilename();
+            String filePath = "/uploads/role-upgrade/" + fileName;
+
+            // 파일 저장 로직 구현 필요
+            // file.transferTo(new File(filePath));
+
+            return filePath;
+
+        } catch (Exception e) {
+            log.error("파일 저장 중 오류 발생: {}", e.getMessage());
+            throw new GeneralException(ErrorCode.FILE_UPLOAD_ERROR);
+        }
+    }
+
+}

--- a/src/main/java/com/snow/popin/domain/user/entity/User.java
+++ b/src/main/java/com/snow/popin/domain/user/entity/User.java
@@ -59,4 +59,9 @@ public class User extends BaseEntity {
     public void changePassword(String newPassword) {
         this.password = newPassword;
     }
+
+    // Role 업데이트
+    public void updateRole(Role newRole){
+        this.role = newRole;
+    }
 }

--- a/src/main/java/com/snow/popin/global/config/WebMvcConfig.java
+++ b/src/main/java/com/snow/popin/global/config/WebMvcConfig.java
@@ -12,8 +12,35 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // CSS 파일들
+        registry.addResourceHandler("/css/**")
+                .addResourceLocations("classpath:/static/css/")
+                .setCachePeriod(0); // 개발 시 캐시 비활성화
+
+        // JavaScript 파일들
+        registry.addResourceHandler("/js/**")
+                .addResourceLocations("classpath:/static/js/")
+                .setCachePeriod(0);
+
+        // 이미지 파일들
         registry.addResourceHandler("/images/**")
-                .addResourceLocations("classpath:/static/images/");
+                .addResourceLocations("classpath:/static/images/")
+                .setCachePeriod(0);
+
+        // 전체 static 폴더
+        registry.addResourceHandler("/static/**")
+                .addResourceLocations("classpath:/static/")
+                .setCachePeriod(0);
+
+        // templates 폴더
+        registry.addResourceHandler("/templates/**")
+                .addResourceLocations("classpath:/static/templates/")
+                .setCachePeriod(0);
+
+        // favicon
+        registry.addResourceHandler("/favicon.ico")
+                .addResourceLocations("classpath:/static/favicon.ico")
+                .setCachePeriod(0);
 
         // 업로드된 파일
         String dir = uploadPath.endsWith("/") ? uploadPath : uploadPath + "/";

--- a/src/main/java/com/snow/popin/global/constant/ErrorCode.java
+++ b/src/main/java/com/snow/popin/global/constant/ErrorCode.java
@@ -7,6 +7,10 @@ import org.springframework.http.HttpStatus;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+
+// TODO: 코드 체계가 일관되지 않고 규칙이 섞여있음.
+//       (10000: Client/Request, 20000: Server/Internal, 40xxx: Domain 등)
+//       추후 정리 필요
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
@@ -21,6 +25,12 @@ public enum ErrorCode {
     LOGIN_FAILED(10005, HttpStatus.BAD_REQUEST, "이메일 또는 비밀번호가 올바르지 않습니다."),
     DUPLICATE_EMAIL(10006,  HttpStatus.BAD_REQUEST, "중복된 이메일입니다."),
 
+    // 역할 승격 관련 에러 코드들
+    DUPLICATE_ROLE_UPGRADE_REQUEST(10007, HttpStatus.BAD_REQUEST, "이미 제출된 계정 전환 요청이 존재합니다."),
+    INVALID_ROLE_UPGRADE_REQUEST(10008, HttpStatus.BAD_REQUEST, "이미 해당 역할이거나 더 높은 역할을 보유하고 있습니다."),
+    ROLE_UPGRADE_REQUEST_NOT_FOUND(10009, HttpStatus.NOT_FOUND, "계정 전환 요청을 찾을 수 없습니다."),
+    INVALID_REQUEST_STATUS(10010, HttpStatus.BAD_REQUEST, "처리할 수 없는 요청 상태입니다."),
+
 
     INTERNAL_ERROR(20000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
     SPRING_INTERNAL_ERROR(20001, HttpStatus.INTERNAL_SERVER_ERROR, "스프링 오류: 서버 내부 오류입니다."),
@@ -31,6 +41,7 @@ public enum ErrorCode {
     UNAUTHORIZED(20005, HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
     CONFLICT(20006, HttpStatus.CONFLICT, "리소스 충돌이 발생했습니다."),
 
+    FILE_UPLOAD_ERROR(20007, HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 중 오류가 발생했습니다."),
 
     POPUP_NOT_FOUND(40404, HttpStatus.NOT_FOUND, "팝업을 찾을 수 없습니다"),
     POPUP_ACCESS_DENIED(40304, HttpStatus.FORBIDDEN, "팝업 접근 권한이 없습니다"),

--- a/src/main/resources/static/auth/login.html
+++ b/src/main/resources/static/auth/login.html
@@ -6,8 +6,13 @@
     <title>로그인 - POPIN</title>
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/login.css">
+    <style>
+        /* header, footer 자리 맞추기 */
+        body { padding-bottom: 64px; }
+    </style>
 </head>
 <body>
+<div id="app-header-mount"></div>
 <div class="login-container">
     <div class="login-card">
         <div class="login-header">
@@ -41,12 +46,32 @@
     </div>
 </div>
 
+<div id="app-footer-mount"></div>
+
 <!-- JavaScript 파일들 로드 -->
 <script src="/js/api.js"></script>
 <script src="/js/auth/loginApi.js"></script>
 <script src="/js/auth/loginValidator.js"></script>
 <script src="/js/auth/loginUI.js"></script>
 <script src="/js/auth/loginController.js"></script>
+
+<script>
+    async function injectPartial(selector, url) {
+        const mount = document.querySelector(selector);
+        if (!mount) return;
+        try {
+            const res = await fetch(url, { cache: 'no-cache' });
+            if (!res.ok) throw new Error(res.status + ' ' + res.statusText);
+            mount.innerHTML = await res.text();
+        } catch (err) {
+            console.warn('Include failed:', url, err);
+        }
+    }
+    document.addEventListener('DOMContentLoaded', function () {
+        injectPartial('#app-header-mount', '../templates/components/header.html');
+        injectPartial('#app-footer-mount', '../templates/components/footer.html');
+    });
+</script>
 
 <script>
     // 페이지 로드 완료 후 로그인 컨트롤러 초기화

--- a/src/main/resources/static/auth/signup.html
+++ b/src/main/resources/static/auth/signup.html
@@ -6,33 +6,16 @@
     <title>회원가입 - POPIN</title>
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/signup.css">
+    <style>
+        body { padding-bottom: 64px; }
+    </style>
 </head>
 <body>
+
+<div id="app-header-mount"></div>
+
 <div class="signup-container">
     <div class="signup-card">
-        <div class="signup-header">
-            <button class="back-btn" onclick="history.back()">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="m15 18-6-6 6-6"></path>
-                </svg>
-            </button>
-            <div class="logo">
-                <div class="logo-bubble">
-                    <span class="logo-text">POPIN</span>
-                </div>
-            </div>
-            <div class="header-right">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
-                    <path d="m13.73 21a2 2 0 0 1-3.46 0"></path>
-                </svg>
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
-                    <circle cx="12" cy="7" r="4"></circle>
-                </svg>
-            </div>
-        </div>
-
         <div id="alert-container" class="alert"></div>
 
         <form id="signupForm" novalidate>
@@ -171,12 +154,35 @@
     </div>
 </div>
 
+<div id="app-footer-mount"></div>
+
 <!-- JavaScript 파일들 로드 -->
 <script src="/js/api.js"></script>
 <script src="/js/auth/signupApi.js"></script>
 <script src="/js/auth/signupValidator.js"></script>
 <script src="/js/auth/signupUI.js"></script>
 <script src="/js/auth/signupController.js"></script>
+
+
+<script>
+    /* include header/footer partials */
+    async function injectPartial(selector, url) {
+        const mount = document.querySelector(selector);
+        if (!mount) return;
+        try {
+            const res = await fetch(url, { cache: 'no-cache' });
+            if (!res.ok) throw new Error(res.status + ' ' + res.statusText);
+            mount.innerHTML = await res.text();
+        } catch (err) {
+            console.warn('Include failed:', url, err);
+        }
+    }
+    document.addEventListener('DOMContentLoaded', function () {
+        // from /static/auth/signup.html -> /static/templates/components/*.html
+        injectPartial('#app-header-mount', '../templates/components/header.html');
+        injectPartial('#app-footer-mount', '../templates/components/footer.html');
+    });
+</script>
 
 <script>
     // 페이지 로드 완료 후 회원가입 컨트롤러 초기화

--- a/src/main/resources/static/css/role-upgrade.css
+++ b/src/main/resources/static/css/role-upgrade.css
@@ -1,0 +1,329 @@
+/* 승격 요청 페이지 스타일 */
+
+/* 컨테이너 */
+.upgrade-container {
+    max-width: 600px;
+    margin: 0 auto;
+    background: white;
+    min-height: 100vh;
+    box-shadow: 0 0 20px rgba(0,0,0,0.1);
+}
+
+.upgrade-card {
+    background: white;
+    min-height: 100vh;
+}
+
+/* 헤더 */
+.upgrade-header {
+    background: white;
+    padding: 16px 20px;
+    border-bottom: 1px solid #e9ecef;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.back-btn {
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+    color: #6c757d;
+    padding: 8px;
+}
+
+.back-btn svg {
+    width: 24px;
+    height: 24px;
+}
+
+.logo {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+}
+
+.logo-bubble {
+    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    color: white;
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-weight: bold;
+    font-size: 16px;
+    position: relative;
+}
+
+.logo-bubble::before,
+.logo-bubble::after {
+    content: '';
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    background: #6366f1;
+    border-radius: 50%;
+    top: -6px;
+}
+
+.logo-bubble::before {
+    left: 20px;
+}
+
+.logo-bubble::after {
+    right: 20px;
+}
+
+.header-right {
+    display: flex;
+    gap: 12px;
+}
+
+.header-right svg {
+    width: 20px;
+    height: 20px;
+    color: #6c757d;
+    cursor: pointer;
+}
+
+/* 탭 네비게이션 */
+.tab-container {
+    display: flex;
+    background: white;
+    border-bottom: 1px solid #e9ecef;
+    padding: 0 20px;
+}
+
+.tab-btn {
+    flex: 1;
+    padding: 16px;
+    background: none;
+    border: none;
+    font-size: 16px;
+    font-weight: 500;
+    cursor: pointer;
+    color: #6c757d;
+    border-bottom: 3px solid transparent;
+    transition: all 0.3s ease;
+    border-radius: 8px 8px 0 0;
+    margin: 0 4px;
+}
+
+.tab-btn.active {
+    color: #6366f1;
+    border-bottom-color: #6366f1;
+    background: #f8f9ff;
+}
+
+.tab-btn:hover:not(.active) {
+    background: #f8f9fa;
+    color: #495057;
+}
+
+/* 폼 컨테이너 */
+.form-container {
+    padding: 24px 20px;
+}
+
+/* Hidden 클래스 */
+.hidden {
+    display: none !important;
+}
+
+/* 폼 스타일링 */
+.form-group {
+    margin-bottom: 24px;
+}
+
+.form-label {
+    display: block;
+    font-weight: 600;
+    color: #212529;
+    margin-bottom: 8px;
+    font-size: 16px;
+}
+
+.form-input {
+    width: 100%;
+    padding: 14px 16px;
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    font-size: 16px;
+    background: white;
+    transition: border-color 0.3s ease;
+    box-sizing: border-box;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+}
+
+.form-input.error {
+    border-color: #dc3545;
+}
+
+textarea.form-input {
+    min-height: 120px;
+    resize: vertical;
+    font-family: inherit;
+}
+
+select.form-input {
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+    background-position: right 12px center;
+    background-repeat: no-repeat;
+    background-size: 16px;
+    padding-right: 40px;
+}
+
+/* 파일 업로드 */
+.file-upload {
+    position: relative;
+}
+
+.file-input {
+    position: absolute;
+    opacity: 0;
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+}
+
+.file-label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 14px 16px;
+    border: 2px dashed #e9ecef;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    background: #f8f9fa;
+    color: #6c757d;
+}
+
+.file-label:hover {
+    border-color: #6366f1;
+    background: #f8f9ff;
+    color: #6366f1;
+}
+
+.file-label svg {
+    width: 20px;
+    height: 20px;
+}
+
+.file-name {
+    margin-top: 8px;
+    font-size: 14px;
+    color: #28a745;
+    font-weight: 500;
+}
+
+/* 에러 메시지 */
+.field-error {
+    color: #dc3545;
+    font-size: 14px;
+    margin-top: 6px;
+}
+
+/* 제출 버튼 */
+.upgrade-btn {
+    width: 100%;
+    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    color: white;
+    border: none;
+    padding: 16px 24px;
+    border-radius: 12px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    margin-top: 20px;
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.upgrade-btn:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(99, 102, 241, 0.3);
+}
+
+.upgrade-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.loading {
+    display: none;
+    width: 20px;
+    height: 20px;
+    border: 2px solid transparent;
+    border-top: 2px solid white;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-right: 8px;
+}
+
+.upgrade-btn.loading .loading {
+    display: inline-block;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* 알림 메시지 */
+.alert {
+    padding: 12px 16px;
+    border-radius: 8px;
+    margin: 20px;
+    font-size: 14px;
+    display: none;
+}
+
+.alert.success {
+    background: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+}
+
+.alert.error {
+    background: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+}
+
+.alert.info {
+    background: #d1ecf1;
+    color: #0c5460;
+    border: 1px solid #bee5eb;
+}
+
+/* 반응형 */
+@media (max-width: 768px) {
+    .upgrade-container {
+        margin: 0;
+        box-shadow: none;
+    }
+
+    .form-container {
+        padding: 20px 16px;
+    }
+
+    .upgrade-header {
+        padding: 12px 16px;
+    }
+
+    .tab-container {
+        padding: 0 16px;
+    }
+}

--- a/src/main/resources/static/js/role-upgrade/roleUpgradeApi.js
+++ b/src/main/resources/static/js/role-upgrade/roleUpgradeApi.js
@@ -1,0 +1,292 @@
+/**
+ * 유저 승격 요청 API 서비스
+ * 승격 요청 관련 HTTP 통신을 담당
+ */
+class RoleUpgradeApi {
+    constructor() {
+        this.baseURL = '/api';
+        this.maxRetries = 3;
+        this.retryDelay = 1000; // 1초
+    }
+
+    /**
+     * 유저 승격 요청 API
+     * @param {Object} requestData 승격 요청 데이터
+     * @param {File} file 첨부 파일 (선택사항)
+     * @returns {Promise<Object>} 승격 요청 응답 데이터
+     */
+    async createUpgradeRequest(requestData, file = null) {
+        for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
+            try {
+                // FormData 생성
+                const formData = new FormData();
+
+                // 요청 데이터를 JSON으로 추가
+                const requestBlob = new Blob([JSON.stringify(requestData)], {
+                    type: 'application/json'
+                });
+                formData.append('request', requestBlob);
+
+                // 파일이 있으면 추가
+                if (file) {
+                    formData.append('documents', file);
+                }
+
+                // 토큰 가져오기
+                const token = this.getStoredToken();
+
+                const headers = {};
+                if (token) {
+                    headers['Authorization'] = `Bearer ${token}`;
+                }
+
+                const response = await fetch(`${this.baseURL}/role-upgrade/request`, {
+                    method: 'POST',
+                    headers: headers,
+                    body: formData
+                });
+
+                const data = await response.json();
+
+                if (!response.ok) {
+                    const errorMessage = data.message || this.getHttpErrorMessage(response.status);
+                    throw new Error(errorMessage);
+                }
+
+                return {
+                    success: true,
+                    message: data.message || '승격 요청이 성공적으로 제출되었습니다.',
+                    requestId: data.requestId
+                };
+
+            } catch (error) {
+                // 네트워크 에러인 경우 재시도
+                if (error instanceof TypeError || error?.name === 'AbortError') {
+                    if (attempt === this.maxRetries) {
+                        throw new Error('네트워크 연결을 확인해주세요. 잠시 후 다시 시도해주세요.');
+                    }
+                    await this.delay(this.retryDelay * attempt);
+                    continue;
+                }
+                // API 에러는 바로 throw
+                throw error;
+            }
+        }
+    }
+
+    /**
+     * 내 승격 요청 목록 조회
+     * @returns {Promise<Array>} 승격 요청 목록
+     */
+    async getMyUpgradeRequests() {
+        try {
+            const token = this.getStoredToken();
+
+            const headers = {
+                'Content-Type': 'application/json'
+            };
+
+            if (token) {
+                headers['Authorization'] = `Bearer ${token}`;
+            }
+
+            const response = await fetch(`${this.baseURL}/user/role-upgrade/my-requests`, {
+                method: 'GET',
+                headers: headers
+            });
+
+            if (!response.ok) {
+                throw new Error('승격 요청 목록 조회 중 오류가 발생했습니다.');
+            }
+
+            return await response.json();
+        } catch (error) {
+            console.error('승격 요청 목록 조회 실패:', error);
+            throw new Error('승격 요청 목록 조회 중 오류가 발생했습니다.');
+        }
+    }
+
+    /**
+     * 승격 요청 상세 조회
+     * @param {number} requestId 요청 ID
+     * @returns {Promise<Object>} 승격 요청 상세 정보
+     */
+    async getUpgradeRequestDetail(requestId) {
+        try {
+            const token = this.getStoredToken();
+
+            const headers = {
+                'Content-Type': 'application/json'
+            };
+
+            if (token) {
+                headers['Authorization'] = `Bearer ${token}`;
+            }
+
+            const response = await fetch(`${this.baseURL}/user/role-upgrade/${requestId}`, {
+                method: 'GET',
+                headers: headers
+            });
+
+            if (!response.ok) {
+                throw new Error('승격 요청 상세 조회 중 오류가 발생했습니다.');
+            }
+
+            return await response.json();
+        } catch (error) {
+            console.error('승격 요청 상세 조회 실패:', error);
+            throw new Error('승격 요청 상세 조회 중 오류가 발생했습니다.');
+        }
+    }
+
+    /**
+     * HTTP 상태 코드에 따른 에러 메시지 반환
+     * @param {number} status HTTP 상태 코드
+     * @returns {string} 에러 메시지
+     */
+    getHttpErrorMessage(status) {
+        const messages = {
+            400: '입력 정보를 확인해주세요.',
+            401: '로그인이 필요합니다.',
+            403: '권한이 없습니다.',
+            404: '요청한 리소스를 찾을 수 없습니다.',
+            409: '이미 처리된 요청이거나 중복된 요청입니다.',
+            422: '입력 데이터가 올바르지 않습니다.',
+            429: '너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요.',
+            500: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+            502: '서버가 일시적으로 사용할 수 없습니다.',
+            503: '서버가 일시적으로 사용할 수 없습니다.'
+        };
+        return messages[status] || `오류가 발생했습니다. (${status})`;
+    }
+
+    /**
+     * 저장된 토큰 가져오기
+     * @returns {string|null} 토큰
+     */
+    getStoredToken() {
+        // api.js의 apiService와 호환성을 위해
+        if (typeof apiService !== 'undefined' && apiService.getStoredToken) {
+            return apiService.getStoredToken();
+        }
+
+        // 직접 토큰 조회
+        return localStorage.getItem('accessToken') || sessionStorage.getItem('accessToken');
+    }
+
+    /**
+     * 지연 함수
+     * @param {number} ms 밀리초
+     * @returns {Promise}
+     */
+    delay(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    /**
+     * 파일 크기 검증
+     * @param {File} file 파일
+     * @param {number} maxSizeMB 최대 크기 (MB)
+     * @returns {boolean} 검증 결과
+     */
+    validateFileSize(file, maxSizeMB = 10) {
+        if (!file) return true;
+
+        const maxSizeBytes = maxSizeMB * 1024 * 1024;
+        return file.size <= maxSizeBytes;
+    }
+
+    /**
+     * 파일 타입 검증
+     * @param {File} file 파일
+     * @param {Array} allowedTypes 허용된 타입 목록
+     * @returns {boolean} 검증 결과
+     */
+    validateFileType(file, allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'application/pdf']) {
+        if (!file) return true;
+
+        return allowedTypes.includes(file.type);
+    }
+
+    /**
+     * 업로드 진행률 콜백과 함께 파일 업로드
+     * @param {Object} requestData 승격 요청 데이터
+     * @param {File} file 첨부 파일
+     * @param {Function} onProgress 진행률 콜백
+     * @returns {Promise<Object>} 업로드 결과
+     */
+    async createUpgradeRequestWithProgress(requestData, file = null, onProgress = null) {
+        return new Promise((resolve, reject) => {
+            const formData = new FormData();
+
+            // 요청 데이터를 JSON으로 추가
+            const requestBlob = new Blob([JSON.stringify(requestData)], {
+                type: 'application/json'
+            });
+            formData.append('request', requestBlob);
+
+            // 파일이 있으면 추가
+            if (file) {
+                formData.append('documents', file);
+            }
+
+            const xhr = new XMLHttpRequest();
+
+            // 진행률 이벤트
+            if (onProgress) {
+                xhr.upload.addEventListener('progress', (e) => {
+                    if (e.lengthComputable) {
+                        const percentComplete = (e.loaded / e.total) * 100;
+                        onProgress(percentComplete);
+                    }
+                });
+            }
+
+            // 완료 이벤트
+            xhr.addEventListener('load', () => {
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    try {
+                        const data = JSON.parse(xhr.responseText);
+                        resolve({
+                            success: true,
+                            message: data.message || '승격 요청이 성공적으로 제출되었습니다.',
+                            requestId: data.requestId
+                        });
+                    } catch (error) {
+                        reject(new Error('응답 데이터 파싱 오류'));
+                    }
+                } else {
+                    try {
+                        const errorData = JSON.parse(xhr.responseText);
+                        reject(new Error(errorData.message || this.getHttpErrorMessage(xhr.status)));
+                    } catch (error) {
+                        reject(new Error(this.getHttpErrorMessage(xhr.status)));
+                    }
+                }
+            });
+
+            // 에러 이벤트
+            xhr.addEventListener('error', () => {
+                reject(new Error('네트워크 오류가 발생했습니다.'));
+            });
+
+            // 타임아웃 이벤트
+            xhr.addEventListener('timeout', () => {
+                reject(new Error('요청 시간이 초과되었습니다.'));
+            });
+
+            // 요청 설정
+            const token = this.getStoredToken();
+            xhr.open('POST', `${this.baseURL}/user/role-upgrade/request`);
+
+            if (token) {
+                xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+            }
+
+            xhr.timeout = 30000; // 30초 타임아웃
+
+            // 요청 전송
+            xhr.send(formData);
+        });
+    }
+}

--- a/src/main/resources/static/js/role-upgrade/roleUpgradeController.js
+++ b/src/main/resources/static/js/role-upgrade/roleUpgradeController.js
@@ -1,0 +1,146 @@
+/**
+ * 유저 승격 요청 페이지 메인 컨트롤러
+ */
+class RoleUpgradeController {
+    constructor() {
+        this.api = new RoleUpgradeApi();
+        this.ui = new RoleUpgradeUI();
+
+        this.init();
+    }
+
+    /**
+     * 컨트롤러 초기화
+     */
+    init() {
+        this.checkUserAuth();
+        this.setupFormSubmission();
+    }
+
+    /**
+     * 사용자 인증 확인
+     */
+    async checkUserAuth() {
+        const token = this.api.getStoredToken();
+
+        if (!token) {
+            this.ui.showAlert('로그인이 필요합니다.', 'error');
+            setTimeout(() => {
+                window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+            }, 2000);
+            return;
+        }
+
+        // 기존 요청 확인
+        try {
+            await this.checkExistingRequest();
+        } catch (error) {
+            console.warn('기존 요청 확인 실패:', error);
+        }
+    }
+
+    /**
+     * 기존 승격 요청 확인
+     */
+    async checkExistingRequest() {
+        try {
+            const requests = await this.api.getMyUpgradeRequests();
+            const pendingRequest = requests.find(req => req.status === 'PENDING');
+
+            if (pendingRequest) {
+                this.ui.showAlert('이미 제출된 승격 요청이 있습니다. 관리자 검토를 기다려주세요.', 'info');
+                this.ui.elements.submitBtn.disabled = true;
+                this.ui.elements.submitBtn.querySelector('.btn-text').textContent = '처리 대기 중';
+            }
+        } catch (error) {
+            console.warn('기존 요청 확인 중 오류:', error);
+        }
+    }
+
+    /**
+     * 폼 제출 이벤트 설정
+     */
+    setupFormSubmission() {
+        this.ui.elements.form.addEventListener('submit', (e) => {
+            this.handleSubmit(e);
+        });
+    }
+
+    /**
+     * 폼 제출 처리
+     */
+    async handleSubmit(e) {
+        e.preventDefault();
+
+        // 클라이언트 검증
+        if (!this.ui.validateForm()) {
+            this.ui.showAlert('입력 정보를 확인해주세요.', 'error');
+            return;
+        }
+
+        // 요청 데이터 준비
+        const requestData = this.ui.getUpgradeRequestData();
+        const selectedFile = this.ui.getSelectedFile();
+
+        // 최종 검증
+        if (!this.validateSubmissionData(requestData, selectedFile)) {
+            return;
+        }
+
+        this.ui.toggleLoading(true);
+
+        try {
+            const response = await this.api.createUpgradeRequest(requestData, selectedFile);
+
+            if (response.success) {
+                this.ui.showAlert(response.message || '승격 요청이 성공적으로 제출되었습니다!', 'success');
+                this.ui.resetForm();
+
+                setTimeout(() => {
+                    window.location.href = '/';
+                }, 3000);
+            } else {
+                throw new Error(response.message || '승격 요청에 실패했습니다.');
+            }
+        } catch (error) {
+            console.error('승격 요청 실패:', error);
+            this.handleSubmissionError(error);
+        } finally {
+            this.ui.toggleLoading(false);
+        }
+    }
+
+    /**
+     * 제출 데이터 검증
+     */
+    validateSubmissionData(requestData, file) {
+        if (!requestData.requestedRole) {
+            this.ui.showAlert('요청할 역할을 선택해주세요.', 'error');
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * 제출 에러 처리
+     */
+    handleSubmissionError(error) {
+        let errorMessage = error.message || '승격 요청 중 오류가 발생했습니다.';
+
+        if (error.message.includes('이미 제출된')) {
+            errorMessage = '이미 제출된 승격 요청이 있습니다. 관리자 검토를 기다려주세요.';
+            this.ui.elements.submitBtn.disabled = true;
+            this.ui.elements.submitBtn.querySelector('.btn-text').textContent = '처리 대기 중';
+        } else if (error.message.includes('권한')) {
+            errorMessage = '해당 역할로 승격할 권한이 없습니다.';
+        } else if (error.message.includes('로그인')) {
+            errorMessage = '로그인이 필요합니다. 로그인 페이지로 이동합니다.';
+            setTimeout(() => {
+                window.location.href = '/auth/login?redirect=' + encodeURIComponent(window.location.pathname);
+            }, 2000);
+        }
+
+        this.ui.showAlert(errorMessage, 'error');
+    }
+}

--- a/src/main/resources/static/js/role-upgrade/roleUpgradeUI.js
+++ b/src/main/resources/static/js/role-upgrade/roleUpgradeUI.js
@@ -1,0 +1,387 @@
+/**
+ * 역할 승격 요청 UI 관리 클래스
+ */
+class RoleUpgradeUI {
+    constructor() {
+        this.activeTab = 'guest'; // 기본값: 기업
+        this.elements = this.getElements();
+
+        this.init();
+    }
+
+    /**
+     * DOM 요소 가져오기
+     */
+    getElements() {
+        return {
+            form: document.getElementById('upgradeForm'),
+            tabBtns: document.querySelectorAll('.tab-btn'),
+
+            // 폼 필드들
+            companyInput: document.getElementById('company'),
+            companyLabel: document.getElementById('company-label'),
+            businessNumberInput: document.getElementById('businessNumber'),
+            permissionSelect: document.getElementById('permission'),
+            additionalTextarea: document.getElementById('additional'),
+            businessFileInput: document.getElementById('businessFile'),
+
+            // 그룹 요소들
+            roleGroup: document.getElementById('role-group'),
+
+            // 에러 표시 요소들
+            companyError: document.getElementById('company-error'),
+            businessNumberError: document.getElementById('businessNumber-error'),
+            permissionError: document.getElementById('permission-error'),
+            additionalError: document.getElementById('additional-error'),
+            fileError: document.getElementById('file-error'),
+
+            // 기타
+            alertContainer: document.getElementById('alert-container'),
+            fileNameDisplay: document.getElementById('file-name'),
+            submitBtn: document.getElementById('upgradeBtn')
+        };
+    }
+
+    /**
+     * UI 초기화
+     */
+    init() {
+        this.setupTabSwitching();
+        this.setupFormValidation();
+        this.setupFileUpload();
+
+        // 초기 상태 설정
+        this.switchTab('guest');
+    }
+
+    /**
+     * 탭 전환 이벤트 설정
+     */
+    setupTabSwitching() {
+        this.elements.tabBtns.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const tab = btn.getAttribute('data-tab');
+                this.switchTab(tab);
+            });
+        });
+    }
+
+    /**
+     * 폼 유효성 검사 이벤트 설정
+     */
+    setupFormValidation() {
+        // 회사명/공간 표시명 입력
+        if (this.elements.companyInput) {
+            this.elements.companyInput.addEventListener('blur', () => {
+                this.validateField('company');
+            });
+        }
+
+        // 사업자등록번호 입력
+        if (this.elements.businessNumberInput) {
+            this.elements.businessNumberInput.addEventListener('input', (e) => {
+                // 숫자와 하이픈만 허용
+                e.target.value = e.target.value.replace(/[^0-9-]/g, '');
+            });
+
+            this.elements.businessNumberInput.addEventListener('blur', () => {
+                this.validateField('businessNumber');
+            });
+        }
+
+        // 권한 선택
+        if (this.elements.permissionSelect) {
+            this.elements.permissionSelect.addEventListener('change', () => {
+                this.validateField('permission');
+            });
+        }
+
+        // 추가 작성 사항
+        if (this.elements.additionalTextarea) {
+            this.elements.additionalTextarea.addEventListener('blur', () => {
+                this.validateField('additional');
+            });
+        }
+
+        // 파일 업로드
+        if (this.elements.businessFileInput) {
+            this.elements.businessFileInput.addEventListener('change', (e) => {
+                this.handleFileSelect(e.target.files[0]);
+            });
+        }
+    }
+
+    /**
+     * 탭 전환 (수정된 로직)
+     * @param {string} tab 탭 이름 ('guest' 또는 'host')
+     */
+    switchTab(tab) {
+        this.activeTab = tab;
+
+        if (tab === 'guest') {
+            this.elements.companyLabel.textContent = '회사명';
+            this.elements.companyInput.placeholder = '회사명을 입력해 주세요';
+            this.showRoleField();
+        } else {
+            this.elements.companyLabel.textContent = '공간 표시명';
+            this.elements.companyInput.placeholder = '공간 표시명을 입력해 주세요';
+            this.hideRoleField();
+        }
+
+        // 탭 활성화 토글 (tabButtons → tabBtns)
+        this.elements.tabBtns.forEach(btn => btn.classList.remove('active'));
+        const activeBtn = Array.from(this.elements.tabBtns).find(btn => btn.dataset.tab === tab);
+        if (activeBtn) activeBtn.classList.add('active');
+    }
+
+    /**
+     * 권한 필드 표시
+     */
+    showRoleField() {
+        this.elements.roleGroup.classList.remove('hidden');
+    }
+
+    /**
+     * 권한 필드 숨기기
+     */
+    hideRoleField() {
+        this.elements.roleGroup.classList.add('hidden');
+        // 권한 선택 초기화
+        if (this.elements.permissionSelect) {
+            this.elements.permissionSelect.value = '';
+        }
+    }
+
+    /**
+     * 파일 업로드 설정
+     */
+    setupFileUpload() {
+        // 파일 선택 영역 클릭 이벤트
+        const fileLabel = document.querySelector('.file-label');
+        if (fileLabel) {
+            fileLabel.addEventListener('click', () => {
+                this.elements.businessFileInput.click();
+            });
+        }
+    }
+
+    /**
+     * 파일 선택 처리
+     */
+    handleFileSelect(file) {
+        if (!file) {
+            this.elements.fileNameDisplay.textContent = '';
+            this.clearFieldError('file');
+            return;
+        }
+
+        // 파일 검증 (이제 선택사항이므로 에러가 나면 표시만)
+        const validation = RoleUpgradeValidator.validateFile(file);
+        if (!validation.isValid) {
+            this.showFieldError('file', validation.message);
+            this.elements.businessFileInput.value = '';
+            this.elements.fileNameDisplay.textContent = '';
+            return;
+        }
+
+        // 파일명 표시
+        this.elements.fileNameDisplay.textContent = file.name;
+        this.clearFieldError('file');
+    }
+
+    /**
+     * 필드별 유효성 검사
+     */
+    validateField(fieldName) {
+        const value = this.getFieldValue(fieldName);
+        const result = RoleUpgradeValidator.validateField(fieldName, value, this.activeTab);
+
+        if (result.isValid) {
+            this.clearFieldError(fieldName);
+        } else {
+            this.showFieldError(fieldName, result.message);
+        }
+
+        return result.isValid;
+    }
+
+    /**
+     * 필드 값 가져오기
+     */
+    getFieldValue(fieldName) {
+        switch (fieldName) {
+            case 'company':
+                return this.elements.companyInput?.value?.trim() || '';
+            case 'businessNumber':
+                return this.elements.businessNumberInput?.value?.trim() || '';
+            case 'permission':
+                return this.elements.permissionSelect?.value || '';
+            case 'additional':
+                return this.elements.additionalTextarea?.value?.trim() || '';
+            default:
+                return '';
+        }
+    }
+
+    /**
+     * 전체 폼 유효성 검사 (파일 검증 제거)
+     */
+    validateForm() {
+        const errors = {};
+
+        // 기본 필수 필드
+        const requiredFields = ['company', 'businessNumber'];
+
+        // 기업(guest) 탭에서만 권한 필수
+        if (this.activeTab === 'guest') {
+            requiredFields.push('permission');
+        }
+
+        requiredFields.forEach(field => {
+            const value = this.getFieldValue(field);
+            const validation = RoleUpgradeValidator.validateField(field, value, this.activeTab);
+            if (!validation.isValid) {
+                errors[field] = validation.message;
+            }
+        });
+
+        return errors;
+    }
+
+
+    /**
+     * 승격 요청 데이터 가져오기
+     */
+    getUpgradeRequestData() {
+        const isBusiness = this.activeTab === 'guest'; // 기업 탭 여부
+
+        // 폼 값을 payload로 모으기
+        const payload = {
+            company: this.getFieldValue('company'),
+            businessNumber: this.getFieldValue('businessNumber'),
+            additional: this.getFieldValue('additional'),
+            ...(isBusiness ? { permission: this.getFieldValue('permission') } : {})
+        };
+
+        // 기업(guest) → HOST, 공간제공자(host) → PROVIDER
+        return {
+            requestedRole: isBusiness ? 'HOST' : 'PROVIDER',
+            // 대부분 스프링 컨트롤러에서 payload를 String으로 받으므로 문자열로 전송
+            payload: JSON.stringify(payload)
+        };
+    }
+
+    /**
+     * 선택된 파일 가져오기
+     */
+    getSelectedFile() {
+        return this.elements.businessFileInput?.files[0] || null;
+    }
+
+    /**
+     * 필드 에러 표시
+     */
+    showFieldError(fieldName, message) {
+        const errorElement = this.elements[fieldName + 'Error'];
+        const inputElement = this.getInputElement(fieldName);
+
+        if (errorElement) {
+            errorElement.textContent = message;
+        }
+
+        if (inputElement) {
+            inputElement.classList.add('error');
+        }
+    }
+
+    /**
+     * 필드 에러 제거
+     */
+    clearFieldError(fieldName) {
+        const errorElement = this.elements[fieldName + 'Error'];
+        const inputElement = this.getInputElement(fieldName);
+
+        if (errorElement) {
+            errorElement.textContent = '';
+        }
+
+        if (inputElement) {
+            inputElement.classList.remove('error');
+        }
+    }
+
+    /**
+     * 입력 요소 가져오기
+     */
+    getInputElement(fieldName) {
+        switch (fieldName) {
+            case 'company':
+                return this.elements.companyInput;
+            case 'businessNumber':
+                return this.elements.businessNumberInput;
+            case 'permission':
+                return this.elements.permissionSelect;
+            case 'additional':
+                return this.elements.additionalTextarea;
+            case 'file':
+                return this.elements.businessFileInput;
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * 모든 에러 제거
+     */
+    clearErrors() {
+        const errorFields = ['company', 'businessNumber', 'permission', 'additional', 'file'];
+        errorFields.forEach(field => {
+            this.clearFieldError(field);
+        });
+    }
+
+    /**
+     * 알림 메시지 표시
+     */
+    showAlert(message, type = 'info') {
+        const container = this.elements.alertContainer;
+        if (!container) return;
+
+        container.textContent = message;
+        container.className = `alert ${type}`;
+        container.style.display = 'block';
+
+        // 3초 후 자동 숨김
+        setTimeout(() => {
+            container.style.display = 'none';
+        }, 3000);
+    }
+
+    /**
+     * 로딩 상태 토글
+     */
+    toggleLoading(isLoading) {
+        if (!this.elements.submitBtn) return;
+
+        if (isLoading) {
+            this.elements.submitBtn.classList.add('loading');
+            this.elements.submitBtn.disabled = true;
+        } else {
+            this.elements.submitBtn.classList.remove('loading');
+            this.elements.submitBtn.disabled = false;
+        }
+    }
+
+    /**
+     * 폼 초기화
+     */
+    resetForm() {
+        if (this.elements.form) {
+            this.elements.form.reset();
+        }
+
+        this.elements.fileNameDisplay.textContent = '';
+        this.clearErrors();
+        this.switchTab('guest'); // 기본 탭으로 초기화
+    }
+}

--- a/src/main/resources/static/js/role-upgrade/roleUpgradeValidator.js
+++ b/src/main/resources/static/js/role-upgrade/roleUpgradeValidator.js
@@ -1,0 +1,225 @@
+/**
+ * 유저 승격 요청 폼 검증 유틸리티
+ */
+class RoleUpgradeValidator {
+
+    /**
+     * 회사명/공간명 검증
+     */
+    static validateCompany(company) {
+        if (!company || company.trim() === '') {
+            return { isValid: false, message: '회사명을 입력해주세요.' };
+        }
+
+        if (company.trim().length < 2) {
+            return { isValid: false, message: '회사명은 2자 이상 입력해주세요.' };
+        }
+
+        if (company.trim().length > 100) {
+            return { isValid: false, message: '회사명은 100자 이하로 입력해주세요.' };
+        }
+
+        return { isValid: true, message: '' };
+    }
+
+    /**
+     * 사업자등록번호 검증
+     */
+    static validateBusinessNumber(businessNumber) {
+        if (!businessNumber || businessNumber.trim() === '') {
+            return { isValid: false, message: '사업자등록번호를 입력해주세요.' };
+        }
+
+        const cleanNumber = businessNumber.replace(/[^0-9]/g, '');
+
+        if (cleanNumber.length !== 10) {
+            return { isValid: false, message: '사업자등록번호는 10자리 숫자여야 합니다.' };
+        }
+
+        if (!this.isValidBusinessNumber(cleanNumber)) {
+            return { isValid: false, message: '올바르지 않은 사업자등록번호입니다.' };
+        }
+
+        return { isValid: true, message: '' };
+    }
+
+    /**
+     * 권한 검증
+     */
+    static validatePermission(permission) {
+        const validPermissions = ['viewer', 'editor', 'admin'];
+
+        if (!permission || permission.trim() === '') {
+            return { isValid: false, message: '권한을 선택해주세요.' };
+        }
+
+        if (!validPermissions.includes(permission)) {
+            return { isValid: false, message: '올바른 권한을 선택해주세요.' };
+        }
+
+        return { isValid: true, message: '' };
+    }
+
+    /**
+     * 추가 작성 사항 검증
+     */
+    static validateAdditional(additional) {
+        if (!additional || additional.trim() === '') {
+            return { isValid: true, message: '' };
+        }
+
+        if (additional.trim().length > 1000) {
+            return { isValid: false, message: '추가 작성 사항은 1000자 이하로 입력해주세요.' };
+        }
+
+        return { isValid: true, message: '' };
+    }
+
+    /**
+     * 파일 검증 (선택사항으로 변경)
+     */
+    static validateFile(file) {
+        // 파일이 없어도 유효 (선택사항)
+        if (!file) {
+            return { isValid: true, message: '' };
+        }
+
+        // 파일 크기 제한 (10MB)
+        const maxSize = 10 * 1024 * 1024;
+        if (file.size > maxSize) {
+            return { isValid: false, message: '파일 크기는 10MB 이하여야 합니다.' };
+        }
+
+        // 파일 타입 검증
+        const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'application/pdf'];
+        if (!allowedTypes.includes(file.type)) {
+            return { isValid: false, message: 'JPG, PNG, PDF 파일만 업로드 가능합니다.' };
+        }
+
+        return { isValid: true, message: '' };
+    }
+
+    /**
+     * 사업자등록번호 체크섬 검증
+     */
+    static isValidBusinessNumber(businessNumber) {
+        if (businessNumber.length !== 10) return false;
+
+        const weights = [1, 3, 7, 1, 3, 7, 1, 3, 5];
+        let sum = 0;
+
+        for (let i = 0; i < 9; i++) {
+            sum += parseInt(businessNumber[i]) * weights[i];
+        }
+
+        sum += Math.floor((parseInt(businessNumber[8]) * 5) / 10);
+        const checkDigit = (10 - (sum % 10)) % 10;
+
+        return checkDigit === parseInt(businessNumber[9]);
+    }
+
+    /**
+     * 전체 폼 검증
+     */
+    static validateForm(formData, activeTab) {
+        const errors = {};
+
+        // 회사명/공간명 검증
+        const company = formData.get('company');
+        const companyValidation = this.validateCompany(company);
+        if (!companyValidation.isValid) {
+            errors.company = companyValidation.message;
+        }
+
+        // 사업자등록번호 검증
+        const businessNumber = formData.get('businessNumber');
+        const businessValidation = this.validateBusinessNumber(businessNumber);
+        if (!businessValidation.isValid) {
+            errors.businessNumber = businessValidation.message;
+        }
+
+        // 권한 검증 (공간 제공자만)
+        if (activeTab === 'host') {
+            const permission = formData.get('permission');
+            const permissionValidation = this.validatePermission(permission);
+            if (!permissionValidation.isValid) {
+                errors.permission = permissionValidation.message;
+            }
+        }
+
+        // 추가 작성 사항 검증
+        const additional = formData.get('additional');
+        const additionalValidation = this.validateAdditional(additional);
+        if (!additionalValidation.isValid) {
+            errors.additional = additionalValidation.message;
+        }
+
+        return {
+            isValid: Object.keys(errors).length === 0,
+            errors: errors
+        };
+    }
+
+    /**
+     * 실시간 필드 검증
+     */
+    static validateField(fieldName, value, activeTab) {
+        switch (fieldName) {
+            case 'company':
+                return this.validateCompany(value);
+            case 'businessNumber':
+                return this.validateBusinessNumber(value);
+            case 'permission':
+                return this.validatePermission(value);
+            case 'additional':
+                return this.validateAdditional(value);
+            default:
+                return { isValid: true, message: '' };
+        }
+    }
+
+    /**
+     * 사업자등록번호 포맷팅
+     */
+    static formatBusinessNumber(value) {
+        if (!value) return '';
+
+        const numbers = value.replace(/[^0-9]/g, '');
+
+        if (numbers.length <= 3) {
+            return numbers;
+        } else if (numbers.length <= 5) {
+            return numbers.replace(/(\d{3})(\d+)/, '$1-$2');
+        } else {
+            return numbers.replace(/(\d{3})(\d{2})(\d+)/, '$1-$2-$3');
+        }
+    }
+
+    /**
+     * 파일명 포맷팅
+     */
+    static formatFileName(fileName, maxLength = 30) {
+        if (!fileName) return '';
+
+        if (fileName.length <= maxLength) return fileName;
+
+        const extension = fileName.split('.').pop();
+        const name = fileName.substring(0, fileName.lastIndexOf('.'));
+        const truncatedName = name.substring(0, maxLength - extension.length - 4);
+
+        return `${truncatedName}...${extension}`;
+    }
+
+    /**
+     * 파일 크기 포맷팅
+     */
+    static formatFileSize(bytes) {
+        if (bytes === 0) return '0 Bytes';
+
+        const k = 1024;
+        const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+        const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+        return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    }
+}

--- a/src/main/resources/static/templates/pages/role-upgrade-request.html
+++ b/src/main/resources/static/templates/pages/role-upgrade-request.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>계정 전환 요청 - POPIN</title>
+    <link rel="stylesheet" href="/css/layout.css" />
+    <link rel="stylesheet" href="/css/role-upgrade.css">
+</head>
+<body>
+<div class="upgrade-container">
+    <div class="upgrade-card">
+        <!-- 헤더 -->
+        <div class="upgrade-header">
+            <button class="back-btn" onclick="history.back()">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="m15 18-6-6 6-6"></path>
+                </svg>
+            </button>
+            <div class="logo">
+                <div class="logo-bubble">
+                    <span class="logo-text">POPIN</span>
+                </div>
+            </div>
+            <div class="header-right">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
+                    <path d="m13.73 21a2 2 0 0 1-3.46 0"></path>
+                </svg>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
+                    <circle cx="12" cy="7" r="4"></circle>
+                </svg>
+            </div>
+        </div>
+
+        <!-- 탭 버튼 -->
+        <div class="tab-container">
+            <button class="tab-btn active" data-tab="guest">기업</button>
+            <button class="tab-btn" data-tab="host">공간 제공자</button>
+        </div>
+
+        <!-- 알림 메시지 -->
+        <div id="alert-container" class="alert"></div>
+
+        <!-- 폼 -->
+        <div class="form-container">
+            <form id="upgradeForm" novalidate>
+                <!-- 공간 표시명/회사명 -->
+                <div class="form-group" id="company-group">
+                    <label class="form-label" for="company">
+                        <span class="label-text" id="company-label">회사명</span>
+                    </label>
+                    <input
+                            type="text"
+                            id="company"
+                            name="company"
+                            class="form-input"
+                            placeholder="회사명을 입력해 주세요"
+                            autocomplete="organization"
+                    >
+                    <div class="field-error" id="company-error"></div>
+                </div>
+
+                <!-- 사업자등록번호 -->
+                <div class="form-group" id="business-group">
+                    <label class="form-label" for="businessNumber">사업자등록번호</label>
+                    <input
+                            type="text"
+                            id="businessNumber"
+                            name="businessNumber"
+                            class="form-input"
+                            placeholder="사업자 등록번호를 입력해 주세요"
+                            maxlength="12"
+                    >
+                    <div class="field-error" id="businessNumber-error"></div>
+                </div>
+
+                <!-- 권한 선택 (공간 제공자만) -->
+                <div class="form-group hidden" id="role-group">
+                    <label class="form-label" for="permission">권한</label>
+                    <select id="permission" name="permission" class="form-input">
+                        <option value="">권한을 선택해 주세요</option>
+                        <option value="viewer">viewer</option>
+                        <option value="editor">editor</option>
+                        <option value="admin">admin</option>
+                    </select>
+                    <div class="field-error" id="permission-error"></div>
+                </div>
+
+                <!-- 추가 작성 사항 -->
+                <div class="form-group" id="additional-group">
+                    <label class="form-label" for="additional">추가 작성 사항</label>
+                    <textarea
+                            id="additional"
+                            name="additional"
+                            class="form-input"
+                            placeholder="기타 사항을 입력해주세요"
+                            rows="4"
+                    ></textarea>
+                    <div class="field-error" id="additional-error"></div>
+                </div>
+
+                <!-- 사업자등록증 첨부 -->
+                <div class="form-group" id="file-group">
+                    <label class="form-label">사업자등록증 첨부</label>
+                    <div class="file-upload">
+                        <input
+                                type="file"
+                                id="businessFile"
+                                name="businessFile"
+                                class="file-input"
+                                accept="image/*,.pdf"
+                        >
+                        <label for="businessFile" class="file-label">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"></path>
+                                <polyline points="14,2 14,8 20,8"></polyline>
+                                <line x1="16" y1="13" x2="8" y2="13"></line>
+                                <line x1="16" y1="17" x2="8" y2="17"></line>
+                                <polyline points="10,9 9,9 8,9"></polyline>
+                            </svg>
+                            파일 선택
+                        </label>
+                    </div>
+                    <div class="file-name" id="file-name"></div>
+                    <div class="field-error" id="file-error"></div>
+                </div>
+
+                <!-- 제출 버튼 -->
+                <button type="submit" class="upgrade-btn" id="upgradeBtn">
+                    <span class="loading"></span>
+                    <span class="btn-text">요청하기</span>
+                </button>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- JavaScript 파일들 로드 -->
+<script src="/js/api.js"></script>
+<script src="/js/role-upgrade/roleUpgradeApi.js"></script>
+<script src="/js/role-upgrade/roleUpgradeValidator.js"></script>
+<script src="/js/role-upgrade/roleUpgradeUI.js"></script>
+<script src="/js/role-upgrade/roleUpgradeController.js"></script>
+
+<script>
+    // 페이지 로드 완료 후 승격 요청 컨트롤러 초기화
+    document.addEventListener('DOMContentLoaded', function() {
+        new RoleUpgradeController();
+    });
+</script>
+</body>
+</html>

--- a/src/main/resources/static/templates/pages/role-upgrade-request.html
+++ b/src/main/resources/static/templates/pages/role-upgrade-request.html
@@ -10,29 +10,8 @@
 <body>
 <div class="upgrade-container">
     <div class="upgrade-card">
-        <!-- 헤더 -->
-        <div class="upgrade-header">
-            <button class="back-btn" onclick="history.back()">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="m15 18-6-6 6-6"></path>
-                </svg>
-            </button>
-            <div class="logo">
-                <div class="logo-bubble">
-                    <span class="logo-text">POPIN</span>
-                </div>
-            </div>
-            <div class="header-right">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
-                    <path d="m13.73 21a2 2 0 0 1-3.46 0"></path>
-                </svg>
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
-                    <circle cx="12" cy="7" r="4"></circle>
-                </svg>
-            </div>
-        </div>
+        <!-- 헤더 마운트 -->
+        <div id="app-header-mount"></div>
 
         <!-- 탭 버튼 -->
         <div class="tab-container">
@@ -136,6 +115,33 @@
         </div>
     </div>
 </div>
+
+<!-- 푸터 마운트 -->
+<div id="app-footer-mount"></div>
+
+<!-- ▼ 헤더/푸터 주입 스크립트 -->
+<script>
+    async function injectPartial(selector, url) {
+        const mount = document.querySelector(selector);
+        if (!mount) return;
+        try {
+            const res = await fetch(url, { cache: 'no-cache' });
+            if (!res.ok) throw new Error(res.status + ' ' + res.statusText);
+            mount.innerHTML = await res.text();
+        } catch (err) {
+            console.warn('Include failed:', url, err);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        // 같은 폴더라면 './header.html' / './footer.html'
+        injectPartial('#app-header-mount', '../components/header.html');
+        injectPartial('#app-footer-mount', '../components/footer.html');
+
+        // 기존 컨트롤러 초기화 (원래 있던 코드 유지)
+        new RoleUpgradeController();
+    });
+</script>
 
 <!-- JavaScript 파일들 로드 -->
 <script src="/js/api.js"></script>


### PR DESCRIPTION
## 📌 Summary
- resolve: #57
- Related Jira: POP-89

## ✨ Description
기업(guest)=HOST, 공간제공자(host)=PROVIDER로 매핑되는 역할 승격 요청 플로우 최초 구현
프론트(폼/검증/전송) ↔ 백엔드(컨트롤러/서비스/설정/에러코드)까지 엔드투엔드로 연결
요청 본문은 multipart/form-data로 전송하며, JSON(Blob) + 파일 동시 업로드 지원

## 📸 Screenshot
<!-- UI 변화가 없다면 지워주세요 -->
|기능|스크린샷|
|:--:|:--:|
|요청 페이지 : 기업|<img width="910" height="1287" alt="image" src="https://github.com/user-attachments/assets/9e3db445-e819-4001-9c71-4d5e86734752" />|
|요청 페이지 : 공간 제공자|<img width="966" height="1219" alt="image" src="https://github.com/user-attachments/assets/a390c0f0-dce5-4a0e-9c17-2a49a1b07e5e" />|


## 🗒️ Review Point
```
헤더와 푸터 연결해야함
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a role upgrade request page with tabbed UI, real-time validation, and localized (Korean) messages.
  - Enabled file upload (image/PDF) with size/type checks and upload progress.
  - Users can submit upgrade requests, view their request history/details, and see pending status.
  - Improved backend handling of requests and documents with clear success responses and user-friendly error messages.

- Chores
  - Expanded static asset serving (CSS/JS/images/templates) and disabled caching to ensure the latest UI assets load during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->