### PR TITLE
feat #POP-117: 환경설정에 알림 on/off 기능 추가

### DIFF
--- a/src/main/java/com/snow/popin/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/snow/popin/domain/notification/controller/NotificationController.java
@@ -1,6 +1,6 @@
 package com.snow.popin.domain.notification.controller;
 
-import com.snow.popin.domain.notification.dto.NotificationResponse;
+import com.snow.popin.domain.notification.dto.NotificationResponseDto;
 import com.snow.popin.domain.notification.entity.Notification;
 import com.snow.popin.domain.notification.entity.NotificationType;
 import com.snow.popin.domain.notification.service.NotificationService;
@@ -30,13 +30,13 @@ public class NotificationController {
 
     /** 내 알림 목록 조회 */
     @GetMapping("/me")
-    public ResponseEntity<List<NotificationResponse>> getMyNotifications() {
+    public ResponseEntity<List<NotificationResponseDto>> getMyNotifications() {
         Long userId = userUtil.getCurrentUserId();
 
         List<Notification> list = notificationService.getUserNotifications(userId);
         return ResponseEntity.ok(
                 list.stream()
-                        .map(NotificationResponse::from)
+                        .map(NotificationResponseDto::from)
                         .collect(Collectors.toList())
         );
     }
@@ -82,14 +82,14 @@ public class NotificationController {
         );
 
         if (n != null) {
-            sendToClient(userId, NotificationResponse.from(n));
+            sendToClient(userId, NotificationResponseDto.from(n));
         }
 
         return ResponseEntity.ok().build();
     }
 
     /** 특정 유저에게 SSE 전송 */
-    public static void sendToClient(Long userId, NotificationResponse dto) {
+    public static void sendToClient(Long userId, NotificationResponseDto dto) {
         SseEmitter emitter = emitters.get(userId);
         if (emitter != null) {
             try {

--- a/src/main/java/com/snow/popin/domain/notification/controller/NotificationSettingController.java
+++ b/src/main/java/com/snow/popin/domain/notification/controller/NotificationSettingController.java
@@ -1,0 +1,34 @@
+package com.snow.popin.domain.notification.controller;
+
+import com.snow.popin.domain.notification.dto.NotificationSettingRequestDto;
+import com.snow.popin.domain.notification.dto.NotificationSettingResponseDto;
+import com.snow.popin.domain.notification.service.NotificationSettingService;
+import com.snow.popin.global.util.UserUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/notifications/settings")
+@RequiredArgsConstructor
+public class NotificationSettingController {
+
+    private final NotificationSettingService settingService;
+    private final UserUtil userUtil;
+
+    /** 내 알림 설정 조회 */
+    @GetMapping("/me")
+    public ResponseEntity<NotificationSettingResponseDto> getMySettings() {
+        Long userId = userUtil.getCurrentUserId();
+        return ResponseEntity.ok(settingService.getSettings(userId));
+    }
+
+    /** 특정 타입 알림 설정 변경 */
+    @PostMapping("/update")
+    public ResponseEntity<Void> updateSetting(@RequestBody NotificationSettingRequestDto dto) {
+        Long userId = userUtil.getCurrentUserId();
+        settingService.updateSetting(userId, dto.getType(), dto.isEnabled());
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/com/snow/popin/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/snow/popin/domain/notification/dto/NotificationResponseDto.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
-public class NotificationResponse {
+public class NotificationResponseDto {
     private Long id;
     private String message;
     private String type;
@@ -17,8 +17,8 @@ public class NotificationResponse {
     private String link;
     private LocalDateTime createdAt;
 
-    public static NotificationResponse from(Notification n) {
-        return NotificationResponse.builder()
+    public static NotificationResponseDto from(Notification n) {
+        return NotificationResponseDto.builder()
                 .id(n.getId())
                 .message(n.getMessage())
                 .type(n.getType().name())

--- a/src/main/java/com/snow/popin/domain/notification/dto/NotificationSettingRequestDto.java
+++ b/src/main/java/com/snow/popin/domain/notification/dto/NotificationSettingRequestDto.java
@@ -1,0 +1,9 @@
+package com.snow.popin.domain.notification.dto;
+
+import lombok.Getter;
+
+@Getter
+public class NotificationSettingRequestDto {
+    private String type;   // "RESERVATION", "SYSTEM", "EVENT"
+    private boolean enabled;
+}

--- a/src/main/java/com/snow/popin/domain/notification/dto/NotificationSettingResponseDto.java
+++ b/src/main/java/com/snow/popin/domain/notification/dto/NotificationSettingResponseDto.java
@@ -1,0 +1,21 @@
+package com.snow.popin.domain.notification.dto;
+
+import com.snow.popin.domain.notification.entity.NotificationSetting;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationSettingResponseDto {
+    private boolean reservationEnabled;
+    private boolean systemEnabled;
+    private boolean eventEnabled;
+
+    public static NotificationSettingResponseDto from(NotificationSetting setting) {
+        return new NotificationSettingResponseDto(
+                setting.isReservationEnabled(),
+                setting.isSystemEnabled(),
+                setting.isInquiryEnabled()
+        );
+    }
+}

--- a/src/main/java/com/snow/popin/domain/notification/entity/NotificationSetting.java
+++ b/src/main/java/com/snow/popin/domain/notification/entity/NotificationSetting.java
@@ -53,16 +53,12 @@ public class NotificationSetting {
     /**
      * 비즈니스 메소드
      */
-
     public void enableAll() { this.enabled = true; }
     public void disableAll() { this.enabled = false; }
-
     public void enableReservation() { this.reservationEnabled = true; }
     public void disableReservation() { this.reservationEnabled = false; }
-
     public void enableSystem() { this.systemEnabled = true; }
     public void disableSystem() { this.systemEnabled = false; }
-
     public void enableInquiry() { this.inquiryEnabled = true; }
     public void disableInquiry() { this.inquiryEnabled = false; }
 }

--- a/src/main/java/com/snow/popin/domain/notification/entity/NotificationSetting.java
+++ b/src/main/java/com/snow/popin/domain/notification/entity/NotificationSetting.java
@@ -2,7 +2,6 @@ package com.snow.popin.domain.notification.entity;
 
 import com.snow.popin.domain.user.entity.User;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,40 +24,45 @@ public class NotificationSetting {
 
     // 전체 알림 ON/OFF
     @Column(nullable = false)
-    private boolean enabled = true;
+    private boolean enabled;
 
     // 예약 관련 알림
     @Column(nullable = false)
-    private boolean reservationEnabled = true;
+    private boolean reservationEnabled;
 
     // 문의 관련 알림
     @Column(nullable = false)
-    private boolean inquiryEnabled = true;
+    private boolean inquiryEnabled;
 
     // 시스템 알림
     @Column(nullable = false)
-    private boolean systemEnabled = true;
+    private boolean systemEnabled;
 
-    @Builder
-    public NotificationSetting(User user,
-                               boolean enabled,
-                               boolean reservationEnabled,
-                               boolean inquiryEnabled,
-                               boolean systemEnabled) {
+    private NotificationSetting(User user) {
         this.user = user;
-        this.enabled = enabled;
-        this.reservationEnabled = reservationEnabled;
-        this.inquiryEnabled = inquiryEnabled;
-        this.systemEnabled = systemEnabled;
+        this.enabled = true;
+        this.reservationEnabled = true;
+        this.systemEnabled = true;
+        this.inquiryEnabled = true;
     }
 
-    public void update(boolean enabled,
-                       boolean reservationEnabled,
-                       boolean inquiryEnabled,
-                       boolean systemEnabled) {
-        this.enabled = enabled;
-        this.reservationEnabled = reservationEnabled;
-        this.inquiryEnabled = inquiryEnabled;
-        this.systemEnabled = systemEnabled;
+    public static NotificationSetting createDefault(User user) {
+        return new NotificationSetting(user);
     }
+
+    /**
+     * 비즈니스 메소드
+     */
+
+    public void enableAll() { this.enabled = true; }
+    public void disableAll() { this.enabled = false; }
+
+    public void enableReservation() { this.reservationEnabled = true; }
+    public void disableReservation() { this.reservationEnabled = false; }
+
+    public void enableSystem() { this.systemEnabled = true; }
+    public void disableSystem() { this.systemEnabled = false; }
+
+    public void enableInquiry() { this.inquiryEnabled = true; }
+    public void disableInquiry() { this.inquiryEnabled = false; }
 }

--- a/src/main/java/com/snow/popin/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/snow/popin/domain/notification/service/NotificationService.java
@@ -1,7 +1,7 @@
 package com.snow.popin.domain.notification.service;
 
 import com.snow.popin.domain.notification.controller.NotificationController;
-import com.snow.popin.domain.notification.dto.NotificationResponse;
+import com.snow.popin.domain.notification.dto.NotificationResponseDto;
 import com.snow.popin.domain.notification.entity.Notification;
 import com.snow.popin.domain.notification.entity.NotificationSetting;
 import com.snow.popin.domain.notification.entity.NotificationType;
@@ -65,7 +65,7 @@ public class NotificationService {
         Notification saved = notificationRepository.save(notification);
 
         // SSE 푸시
-        NotificationController.sendToClient(userId, NotificationResponse.from(saved));
+        NotificationController.sendToClient(userId, NotificationResponseDto.from(saved));
 
         return saved;
     }

--- a/src/main/java/com/snow/popin/domain/notification/service/NotificationSettingService.java
+++ b/src/main/java/com/snow/popin/domain/notification/service/NotificationSettingService.java
@@ -1,0 +1,59 @@
+package com.snow.popin.domain.notification.service;
+
+import com.snow.popin.domain.notification.dto.NotificationSettingResponseDto;
+import com.snow.popin.domain.notification.entity.NotificationSetting;
+import com.snow.popin.domain.notification.entity.NotificationType;
+import com.snow.popin.domain.notification.repository.NotificationSettingRepository;
+import com.snow.popin.domain.user.entity.User;
+import com.snow.popin.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSettingService {
+
+    private final NotificationSettingRepository settingRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public NotificationSettingResponseDto getSettings(Long userId) {
+        NotificationSetting setting = settingRepository.findByUserId(userId)
+                .orElseGet(() -> createDefaultSetting(userId));
+        return NotificationSettingResponseDto.from(setting);
+    }
+
+    @Transactional
+    public void updateSetting(Long userId, String type, boolean enabled) {
+        NotificationSetting notificationSetting = settingRepository.findByUserId(userId)
+                .orElseGet(() -> createDefaultSetting(userId));
+
+        NotificationType nType = NotificationType.valueOf(type.toUpperCase());
+
+        switch (nType) {
+            case RESERVATION:
+                if (enabled) notificationSetting.enableReservation();
+                else notificationSetting.disableReservation();
+                break;
+
+            case SYSTEM:
+                if (enabled) notificationSetting.enableSystem();
+                else notificationSetting.disableSystem();
+                break;
+
+            case EVENT:
+                if (enabled) notificationSetting.enableInquiry();
+                else notificationSetting.disableInquiry();
+                break;
+        }
+        settingRepository.save(notificationSetting);
+    }
+
+    private NotificationSetting createDefaultSetting(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        NotificationSetting setting = NotificationSetting.createDefault(user);
+        return settingRepository.save(setting);
+    }
+}

--- a/src/main/resources/static/css/mypage/user/user-mypage.css
+++ b/src/main/resources/static/css/mypage/user/user-mypage.css
@@ -239,3 +239,57 @@
 #popup-report-form input[type="file"]::file-selector-button:hover {
     background: #5f7de6;
 }
+
+/* 알림 세팅 */
+.notification-setting-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 0;
+}
+
+.setting-label {
+    font-size: 18px;
+    color: #777777;
+    font-weight: 600;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 46px;
+    height: 24px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background-color: #ccc;
+    transition: .4s;
+    border-radius: 24px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 18px; width: 18px;
+    left: 3px; bottom: 3px;
+    background-color: white;
+    transition: .4s;
+    border-radius: 50%;
+}
+
+input:checked + .slider {
+    background-color: #5a7fdd;
+}
+
+input:checked + .slider:before {
+    transform: translateX(22px);
+}

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -656,6 +656,19 @@ apiService.createReservationNotification = async function(userId) {
 apiService.markNotificationRead = async function(id) {
     return await this.post(`/notifications/${id}/read`);
 };
+
+// === 마이페이지 USER api ===
+apiService.getNotificationSettings = async function() {
+    return await this.get("/notifications/settings/me");
+};
+
+apiService.updateNotificationSetting = async function(type, enabled) {
+    return await this.post("/notifications/settings/update", {
+        type, enabled
+    });
+};
+
+
 // === 마이페이지 HOST api ===
 // 팝업 등록
 apiService.createPopup = async function(data) {
@@ -686,4 +699,3 @@ apiService.deletePopup = async function(popupId) {
 apiService.getMyHostProfile = async function() {
     return await this.get('/hosts/me');
 };
-

--- a/src/main/resources/static/js/mypage/user/user-mypage.js
+++ b/src/main/resources/static/js/mypage/user/user-mypage.js
@@ -2,6 +2,9 @@ document.addEventListener('DOMContentLoaded', async function () {
     await loadComponents();   // header/footer 로드
     initializeLayout();
 
+    loadNotificationSettings();
+    setupNotificationSettingEvents();
+
 
     try {
         // =============================
@@ -211,9 +214,6 @@ document.addEventListener('DOMContentLoaded', async function () {
             });
         }
 
-
-
-
     } catch (err) {
         console.error(err);
         const mc = document.getElementById('main-content') || document.querySelector('.main-content');
@@ -222,4 +222,38 @@ document.addEventListener('DOMContentLoaded', async function () {
         `;
     }
 });
+
+
+// 알림 설정 불러오기
+async function loadNotificationSettings() {
+    try {
+        const settings = await apiService.getNotificationSettings();
+        // 예: { reservationEnabled: true, systemEnabled: false, eventEnabled: true }
+
+        document.getElementById("reservation-toggle").checked = settings.reservationEnabled;
+        document.getElementById("system-toggle").checked = settings.systemEnabled;
+        document.getElementById("event-toggle").checked = settings.eventEnabled;
+    } catch (err) {
+        console.error("알림 설정 불러오기 실패:", err);
+    }
+}
+
+// 이벤트 등록
+function setupNotificationSettingEvents() {
+    document.getElementById("reservation-toggle").addEventListener("change", (e) => {
+        apiService.updateNotificationSetting("RESERVATION", e.target.checked);
+    });
+    document.getElementById("system-toggle").addEventListener("change", (e) => {
+        apiService.updateNotificationSetting("SYSTEM", e.target.checked);
+    });
+    document.getElementById("event-toggle").addEventListener("change", (e) => {
+        apiService.updateNotificationSetting("EVENT", e.target.checked);
+    });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    loadNotificationSettings();
+    setupNotificationSettingEvents();
+});
+
 

--- a/src/main/resources/static/templates/pages/mypage/user/user-mypage.html
+++ b/src/main/resources/static/templates/pages/mypage/user/user-mypage.html
@@ -64,6 +64,34 @@
                 </div>
             </div>
 
+            <!-- 알림설정 -->
+            <div class="card">
+                <h2 class="mypage-title">알림 설정</h2>
+                <div class="notification-settings-container">
+                    <div class="notification-setting-item">
+                        <span class="setting-label">예약 알림</span>
+                        <label class="switch">
+                            <input type="checkbox" id="reservation-toggle">
+                            <span class="slider round"></span>
+                        </label>
+                    </div>
+                    <div class="notification-setting-item">
+                        <span class="setting-label">시스템 알림</span>
+                        <label class="switch">
+                            <input type="checkbox" id="system-toggle">
+                            <span class="slider round"></span>
+                        </label>
+                    </div>
+                    <div class="notification-setting-item">
+                        <span class="setting-label">이벤트 알림</span>
+                        <label class="switch">
+                            <input type="checkbox" id="event-toggle">
+                            <span class="slider round"></span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+
             <!-- 내 서비스 메뉴 -->
             <div class="card mypage-menu">
                 <h2 class="mypage-title">조회</h2>


### PR DESCRIPTION
## 📌 Summary
- resolve: #101 
- Related Jira: POP-117

## ✨ Description
- 환경설정에 알림 on/off 추가
- 알림 설정에 따른 on설정 되어있는 알림만 오도록 완료

## 📸 Screenshot
<!-- UI 변화가 없다면 지워주세요 -->
|기능|스크린샷|
|:--:|:--:|
|환경설정|<img width="1321" height="1029" alt="image" src="https://github.com/user-attachments/assets/b5cd6f4a-63c3-4ce8-88a3-ce1d3c9532d9" />|



## ✅ CheckList
- [ ] 환경설정에 알림 on/off 수정 확인
- [ ] 알림 설정에 따른 on설정 되어있는 알림만 오는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “알림 설정” section to My Page with toggles for 예약, 시스템, and 이벤트 notifications.
  - Settings load automatically on page open and are saved instantly when you change a toggle.
  - New backend support ensures your preferences persist and apply to future notifications.

- Style
  - Introduced sleek toggle switch UI with smooth transitions for a clearer, modern look in the notification settings section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->