### PR TITLE
feat #POP-125: Popup status 업데이트

### DIFF
--- a/src/main/java/com/snow/popin/domain/popup/entity/Popup.java
+++ b/src/main/java/com/snow/popin/domain/popup/entity/Popup.java
@@ -168,6 +168,28 @@ public class Popup extends BaseEntity {
         return ChronoUnit.DAYS.between(now, endDate);
     }
 
+    // 현재 날짜를 기준으로 팝업의 상태를 업데이트
+    public boolean updateStatus() {
+        LocalDate now = LocalDate.now();
+        PopupStatus newStatus = determineStatus(now);
+
+        if (this.status != newStatus) {
+            this.status = newStatus;
+            return true;
+        }
+        return false;
+    }
+
+    private PopupStatus determineStatus(LocalDate now) {
+        if (startDate != null && now.isBefore(startDate)) {
+            return PopupStatus.PLANNED;
+        } else if (endDate != null && now.isAfter(endDate)) {
+            return PopupStatus.ENDED;
+        } else {
+            return PopupStatus.ONGOING;
+        }
+    }
+
     // 테스트용 메서드
     public static Popup createForTest(String title, PopupStatus status, Venue venue) {
         Popup popup = new Popup();

--- a/src/main/java/com/snow/popin/domain/popup/repository/PopupRepository.java
+++ b/src/main/java/com/snow/popin/domain/popup/repository/PopupRepository.java
@@ -168,5 +168,11 @@ public interface PopupRepository extends JpaRepository<Popup, Long>, JpaSpecific
      */
     long countByStatus(PopupStatus status);
 
+    // ONGOING 상태로 변경되어야 할 PLANNED 상태의 팝업 목록을 조회
+    @Query("SELECT p FROM Popup p WHERE p.status = com.snow.popin.domain.popup.entity.PopupStatus.PLANNED AND p.startDate <= :today")
+    List<Popup> findPopupsToUpdateToOngoing(@Param("today") LocalDate today);
 
+    // ENDED 상태로 변경되어야 할 ONGOING 상태의 팝업 목록을 조회
+    @Query("SELECT p FROM Popup p WHERE p.status = com.snow.popin.domain.popup.entity.PopupStatus.ONGOING AND p.endDate < :today")
+    List<Popup> findPopupsToUpdateToEnded(@Param("today") LocalDate today);
 }

--- a/src/main/java/com/snow/popin/domain/popup/service/PopupBatchService.java
+++ b/src/main/java/com/snow/popin/domain/popup/service/PopupBatchService.java
@@ -1,23 +1,24 @@
-package com.snow.popin.domain.popup.service
+package com.snow.popin.domain.popup.service;
 
-import com.snow.popin.domain.popup.entity.Popup
-import com.snow.popin.domain.popup.repository.PopupRepository
-import lombok.RequiredArgsConstructor
-import lombok.extern.slf4j.Slf4j
-import org.springframework.scheduling.annotation.Scheduled
-import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
+import com.snow.popin.domain.popup.entity.Popup;
+import com.snow.popin.domain.popup.repository.PopupRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate
+import java.time.LocalDate;
+import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-class PopupBatchService {
+public class PopupBatchService {
 
     private final PopupRepository popupRepository;
 
-    // 매일 자정, 팝업의 상태를 자동으로 업데이트
+    //매일 자정, 팝업의 상태를 자동으로 업데이트합니다.
     @Transactional
     @Scheduled(cron = "0 0 0 * * *")
     public void updatePopupStatuses() {

--- a/src/main/java/com/snow/popin/domain/popup/service/PopupService.java
+++ b/src/main/java/com/snow/popin/domain/popup/service/PopupService.java
@@ -41,9 +41,17 @@ public class PopupService {
         return PopupListResponseDto.of(popupPage, popupDtos);
     }
 
+    @Transactional
     public PopupDetailResponseDto getPopupDetail(Long popupId) {
         Popup popup = popupRepository.findByIdWithDetails(popupId)
                 .orElseThrow(() -> new PopupNotFoundException(popupId));
+
+        // 실시간으로 상태 업데이트 확인
+        boolean statusChanged = popup.updateStatus();
+        if (statusChanged) {
+            log.info("팝업 ID {}의 상태가 실시간으로 업데이트되었습니다: {}", popup.getId(), popup.getStatus());
+            popupRepository.save(popup); // 변경된 경우 저장
+        }
 
         log.info("팝업 상세 조회 완료 - ID: {}, 제목: {}", popup.getId(), popup.getTitle());
 

--- a/src/test/java/com/snow/popin/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/snow/popin/domain/popup/service/PopupServiceTest.java
@@ -241,6 +241,24 @@ class PopupServiceTest {
         ));
     }
 
+    @Test
+    @DisplayName("팝업 상세 조회 - 실시간 상태 업데이트 (PLANNED -> ONGOING)")
+    void getPopupDetail_실시간_상태업데이트() {
+        // given
+        Long popupId = 1L;
+        Popup popup = Popup.createForTestWithDates("상태 업데이트 팝업", LocalDate.now().minusDays(1), LocalDate.now().plusDays(5), null);
+        popup.setStatusForTest(PopupStatus.PLANNED);
+
+        when(popupRepository.findByIdWithDetails(popupId)).thenReturn(Optional.of(popup));
+
+        // when
+        popupService.getPopupDetail(popupId);
+
+        // then
+        assertThat(popup.getStatus()).isEqualTo(PopupStatus.ONGOING);
+        verify(popupRepository, times(1)).save(popup);
+    }
+
     private PopupListRequestDto createListRequest() {
         PopupListRequestDto request = new PopupListRequestDto();
         request.setPage(0);


### PR DESCRIPTION
## 📌 Summary
- resolve: #115 
- Related Jira: POP-125

## ✨ Description
<!-- 변경 사항 요약 -->
### popup status update 구현
- popup entity에 `updateStatus` 를 추가해 날짜 기준으로 팝업 상태를 업데이트할 수 있도록 구현했습니다.
- `PopupBatchService`를 구현하여 매일 자정 팝업의 상태를 자동으로 업데이트 할 수 있도록 구현했습니다.


## 🗒️ Review Point
```
테스트 완료 했습니다.
```

## ✅ CheckList
- [ ] status update 구현
- [ ] 테스트
