### PR TITLE
feat #POP - 122 :  팝업 별 통계

### DIFF
--- a/src/main/java/com/snow/popin/domain/mission/repository/UserMissionRepository.java
+++ b/src/main/java/com/snow/popin/domain/mission/repository/UserMissionRepository.java
@@ -3,7 +3,10 @@ package com.snow.popin.domain.mission.repository;
 import com.snow.popin.domain.mission.entity.UserMission;
 import com.snow.popin.domain.mission.entity.UserMissionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -13,5 +16,19 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
     long countByUser_IdAndMission_MissionSet_IdAndStatus(Long userId, UUID missionSetId, UserMissionStatus status);
     List<UserMission> findByUser_IdAndMission_MissionSet_Id(Long userId, UUID missionSetId);
     List<UserMission> findByUser_Id(Long userId);
+    /**
+     * 특정 팝업의 특정 기간 내 완료된 미션 수 조회
+     */
+    @Query("SELECT COUNT(um) FROM UserMission um " +
+            "JOIN um.mission m " +
+            "JOIN m.missionSet ms " +
+            "WHERE ms.popupId = :popupId " +
+            "AND um.status = 'COMPLETED' " +
+            "AND um.completedAt BETWEEN :start AND :end")
+    Long countCompletedMissionsByPopupAndDate(
+            @Param("popupId") Long popupId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 
 }

--- a/src/main/java/com/snow/popin/domain/mypage/host/controller/HostPageController.java
+++ b/src/main/java/com/snow/popin/domain/mypage/host/controller/HostPageController.java
@@ -33,4 +33,9 @@ public class HostPageController {
     public String reservationManage(@PathVariable Long id) {
         return "forward:/templates/pages/mypage/host/reservation-manage.html";
     }
+
+    @GetMapping("/mypage/host/popup/{id}/stats")
+    public String popupStatsPage(@PathVariable Long id) {
+        return "forward:/templates/pages/mypage/host/popup-stats.html";
+    }
 }

--- a/src/main/java/com/snow/popin/domain/popupReservation/repository/ReservationRepository.java
+++ b/src/main/java/com/snow/popin/domain/popupReservation/repository/ReservationRepository.java
@@ -2,6 +2,7 @@ package com.snow.popin.domain.popupReservation.repository;
 
 import com.snow.popin.domain.popup.entity.Popup;
 import com.snow.popin.domain.popupReservation.entity.Reservation;
+import com.snow.popin.domain.popupReservation.entity.ReservationStatus;
 import com.snow.popin.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -68,4 +69,23 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     long sumPartySizeByPopupAndReservationDateBetween(@Param("popup") Popup popup,
                                                       @Param("startTime") LocalDateTime startTime,
                                                       @Param("endTime") LocalDateTime endTime);
+    //통계용 메서드
+    /**
+     * 특정 팝업의 특정 기간 내 예약 상태별 개수 조회
+     */
+    Long countByPopupAndReservedAtBetweenAndStatus(
+            Popup popup,
+            LocalDateTime start,
+            LocalDateTime end,
+            ReservationStatus status
+    );
+    /**
+     * 팝업별 예약 상태 개수 조회
+     */
+    Long countByPopupAndStatus(Popup popup, ReservationStatus status);
+
+    /**
+     * 팝업별 상태별 예약 목록 조회 (시간대별 통계용)
+     */
+    List<Reservation> findByPopupAndStatus(Popup popup, ReservationStatus status);
 }

--- a/src/main/java/com/snow/popin/domain/popupstat/controller/PopupStatsController.java
+++ b/src/main/java/com/snow/popin/domain/popupstat/controller/PopupStatsController.java
@@ -1,0 +1,37 @@
+package com.snow.popin.domain.popupstat.controller;
+
+import com.snow.popin.domain.popupstat.dto.PopupStatsResponseDto;
+import com.snow.popin.domain.popupstat.service.PopupStatsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/host/popups")
+@RequiredArgsConstructor
+public class PopupStatsController {
+
+    private final PopupStatsService popupStatsService;
+
+    /**
+     * 특정 팝업의 통계를 조회한다.
+     *
+     * @param popupId 팝업 ID
+     * @param start   조회 시작일
+     * @param end     조회 종료일
+     * @return PopupStatsResponseDto
+     */
+    @GetMapping("/{popupId}/stats")
+    public ResponseEntity<List<PopupStatsResponseDto>> getPopupStats(
+            @PathVariable Long popupId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end
+    ) {
+        List<PopupStatsResponseDto> stats = popupStatsService.getStats(popupId, start, end);
+        return ResponseEntity.ok(stats);
+    }
+}

--- a/src/main/java/com/snow/popin/domain/popupstat/dto/PopupStatsResponseDto.java
+++ b/src/main/java/com/snow/popin/domain/popupstat/dto/PopupStatsResponseDto.java
@@ -1,0 +1,20 @@
+package com.snow.popin.domain.popupstat.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PopupStatsResponseDto {
+
+    private LocalDate date;
+    private Integer hour;
+    private Integer visitorCount;
+    private Integer reservationCount;
+    private Integer canceledCount;
+    private Integer missionCompletedCount;
+
+}

--- a/src/main/java/com/snow/popin/domain/popupstat/service/PopupStatsService.java
+++ b/src/main/java/com/snow/popin/domain/popupstat/service/PopupStatsService.java
@@ -1,0 +1,133 @@
+package com.snow.popin.domain.popupstat.service;
+
+import com.snow.popin.domain.mission.repository.UserMissionRepository;
+import com.snow.popin.domain.popup.entity.Popup;
+import com.snow.popin.domain.popup.repository.PopupRepository;
+import com.snow.popin.domain.popupReservation.entity.Reservation;
+import com.snow.popin.domain.popupReservation.entity.ReservationStatus;
+import com.snow.popin.domain.popupReservation.repository.ReservationRepository;
+import com.snow.popin.domain.popupstat.dto.PopupStatsResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+
+/**
+ * 팝업에 대한 다양한 통계 데이터를 계산한다.
+ * - 일별 예약/방문자/취소/미션 수행자 수
+ * - 시간대별 방문자 수
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PopupStatsService {
+
+    private final PopupRepository popupRepository;
+    private final ReservationRepository reservationRepository;
+    private final UserMissionRepository userMissionRepository;
+
+    /**
+     * 특정 팝업에 대한 통계를 조회.
+     * 7일을 기본으로 함.
+     *
+     * @param popupId 팝업 ID
+     * @param start   조회 시작일
+     * @param end     조회 종료일
+     * @return 통계 데이터 리스트 (일별 + 시간대별)
+     */
+    public List<PopupStatsResponseDto> getStats(Long popupId, LocalDate start, LocalDate end) {
+        Popup popup = popupRepository.findById(popupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 팝업입니다."));
+
+        // 날짜 범위 설정 (기본 최근 7일)
+        LocalDate startDate = start != null ? start : LocalDate.now().minusDays(6);
+        LocalDate endDate = end != null ? end : LocalDate.now();
+
+        List<PopupStatsResponseDto> result = new ArrayList<>();
+        result.addAll(calculateDailyStats(popup, startDate, endDate));
+        result.addAll(calculateHourlyStats(popup));
+
+        return result;
+    }
+
+    /**
+     * 일별 통계를 계산.
+     *
+     * @param popup     대상 팝업
+     * @param startDate 시작일
+     * @param endDate   종료일
+     * @return 일별 통계 리스트
+     */
+    private List<PopupStatsResponseDto> calculateDailyStats(Popup popup, LocalDate startDate, LocalDate endDate) {
+        List<PopupStatsResponseDto> dailyStats = new ArrayList<>();
+
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            LocalDateTime dayStart = date.atStartOfDay();
+            LocalDateTime dayEnd = date.atTime(23, 59, 59);
+
+            Long reservationCount = reservationRepository.countByPopupAndReservedAtBetweenAndStatus(
+                    popup, dayStart, dayEnd, ReservationStatus.RESERVED
+            );
+
+            Long canceledCount = reservationRepository.countByPopupAndReservedAtBetweenAndStatus(
+                    popup, dayStart, dayEnd, ReservationStatus.CANCELLED
+            );
+
+            Long visitorCount = reservationRepository.countByPopupAndReservedAtBetweenAndStatus(
+                    popup, dayStart, dayEnd, ReservationStatus.VISITED
+            );
+
+            Long missionCount = userMissionRepository.countCompletedMissionsByPopupAndDate(
+                    popup.getId(), dayStart, dayEnd
+            );
+
+            dailyStats.add(PopupStatsResponseDto.builder()
+                    .date(date)
+                    .hour(null)
+                    .visitorCount(visitorCount.intValue())
+                    .reservationCount(reservationCount.intValue())
+                    .canceledCount(canceledCount.intValue())
+                    .missionCompletedCount(missionCount.intValue())
+                    .build());
+        }
+
+        return dailyStats;
+    }
+
+    /**
+     * 시간대별 방문자 통계를 계산.
+     * 예약의 reservedAt 사용.
+     *
+     * @param popup 대상 팝업
+     * @return 시간대별 통계 리스트
+     */
+    private List<PopupStatsResponseDto> calculateHourlyStats(Popup popup) {
+        List<PopupStatsResponseDto> hourlyStats = new ArrayList<>();
+        Map<Integer, Integer> hourlyVisitorMap = new HashMap<>();
+
+        List<Reservation> allReservations = reservationRepository.findByPopupAndStatus(popup, ReservationStatus.VISITED);
+
+        for (Reservation reservation : allReservations) {
+            if (reservation.getReservedAt() != null) {
+                int hour = reservation.getReservedAt().getHour();
+                hourlyVisitorMap.put(hour, hourlyVisitorMap.getOrDefault(hour, 0) + 1);
+            }
+        }
+
+        for (Map.Entry<Integer, Integer> entry : hourlyVisitorMap.entrySet()) {
+            hourlyStats.add(PopupStatsResponseDto.builder()
+                    .date(LocalDate.now())
+                    .hour(entry.getKey())
+                    .visitorCount(entry.getValue())
+                    .reservationCount(0)
+                    .canceledCount(0)
+                    .missionCompletedCount(0)
+                    .build());
+        }
+
+        return hourlyStats;
+    }
+}

--- a/src/main/resources/static/css/mypage/host/popup-stats.css
+++ b/src/main/resources/static/css/mypage/host/popup-stats.css
@@ -1,0 +1,168 @@
+/* ===== 공통 ===== */
+.main-content {
+    background: #f8fafc;
+    padding: 20px;
+    min-height: 100vh;
+}
+.block {
+    margin-bottom: 24px;
+}
+
+/* 블록 타이틀 */
+.block-title {
+    background: #2563eb !important;
+    border-radius: 12px !important;
+    padding: 20px !important;
+    margin-bottom: 24px !important;
+    box-shadow: 0 4px 20px rgba(37, 99, 235, 0.3) !important;
+    color: white !important;
+    font-size: 18px !important;
+    font-weight: 600 !important;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
+    margin: 0 0 24px 0 !important;
+}
+
+/* 통계 카드 */
+.chart-card {
+    background: white;
+    border-radius: 20px;
+    border: 1px solid rgba(229, 231, 235, 0.5);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+    padding: 24px;
+    margin-bottom: 24px;
+    transition: all 0.3s ease;
+}
+
+.chart-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
+}
+
+.chart-card h4 {
+    font-size: 16px;
+    font-weight: 700;
+    color: #2d3748;
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.chart-card h4::before {
+    content: '';
+    width: 4px;
+    height: 20px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border-radius: 2px;
+}
+
+/* 차트 영역 */
+.chart-card canvas {
+    width: 100% !important;
+    height: 280px !important;
+    border-radius: 12px;
+}
+
+/* 로딩 상태 */
+.loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 200px;
+    color: #718096;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+/* 에러 상태 */
+.error {
+    background: linear-gradient(135deg, #fed7d7 0%, #feb2b2 100%);
+    border: 1px solid #fc8181;
+    border-radius: 12px;
+    padding: 20px;
+    color: #c53030;
+    text-align: center;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+/* 데이터 없음 상태 */
+.no-data {
+    background: linear-gradient(135deg, #f7fafc 0%, #edf2f7 100%);
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 24px;
+    color: #718096;
+    text-align: center;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+/* 통계 카드별 개별 스타일 */
+.chart-card:nth-child(2) {
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.05) 0%, rgba(147, 51, 234, 0.05) 100%);
+}
+
+.chart-card:nth-child(3) {
+    background: linear-gradient(135deg, rgba(16, 185, 129, 0.05) 0%, rgba(5, 150, 105, 0.05) 100%);
+}
+
+.chart-card:nth-child(4) {
+    background: linear-gradient(135deg, rgba(245, 158, 11, 0.05) 0%, rgba(217, 119, 6, 0.05) 100%);
+}
+
+.chart-card:nth-child(5) {
+    background: linear-gradient(135deg, rgba(239, 68, 68, 0.05) 0%, rgba(220, 38, 38, 0.05) 100%);
+}
+
+/* 반응형 */
+@media (max-width: 480px) {
+    .main-content {
+        padding: 16px;
+    }
+
+    .chart-card {
+        padding: 20px;
+        border-radius: 16px;
+    }
+
+    .chart-card h4 {
+        font-size: 14px;
+    }
+
+    .chart-card canvas {
+        height: 220px !important;
+    }
+
+    .loading {
+        height: 150px;
+        font-size: 13px;
+    }
+
+    .block-title {
+        padding: 16px !important;
+        font-size: 16px !important;
+    }
+}
+.period-buttons {
+    display: flex;
+    gap: 8px;
+    margin: 12px 16px 20px 16px;
+}
+
+.btn-period {
+    flex: 1;
+    padding: 8px 12px;
+    border-radius: 8px;
+    border: 1px solid #2563eb;
+    background: white;
+    color: #2563eb;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-period:hover {
+    background: #2563eb;
+    color: white;
+}

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -584,6 +584,13 @@ apiService.deletePopup = async function(popupId) {
 apiService.getMyHostProfile = async function() {
     return await this.get('/hosts/me');
 };
+// 팝업 통계
+apiService.getPopupStats = async function(popupId, params = {}) {
+    const sp = new URLSearchParams(params);
+    const query = sp.toString() ? `?${sp.toString()}` : '';
+    return await this.get(`/host/popups/${encodeURIComponent(popupId)}/stats${query}`);
+};
+
 // === 채팅 api ===
 apiService.getChatMessages = async function(reservationId) {
     return await this.get(`/chat/${encodeURIComponent(reservationId)}/messages`);

--- a/src/main/resources/static/js/mypage/host/mpg-host.js
+++ b/src/main/resources/static/js/mypage/host/mpg-host.js
@@ -76,7 +76,7 @@ const HostPage = {
             window.location.href = `/mypage/host/popup/${popup.id}/reservation`;
         });
         card.querySelector('.btn-stats').addEventListener('click', () => {
-            alert('통계는 준비중입니다.');
+            Pages.popupStats(popup.id);
         });
     },
 

--- a/src/main/resources/static/js/mypage/host/popup-stats.js
+++ b/src/main/resources/static/js/mypage/host/popup-stats.js
@@ -1,0 +1,263 @@
+document.addEventListener("DOMContentLoaded", async () => {
+    const pathParts = window.location.pathname.split("/");
+    const popupId = pathParts[4]; // /mypage/host/popup/{id}/stats → index 4가 {id}
+
+    try {
+        const data = await apiService.getPopupStats(popupId);
+
+        if (!data || data.length === 0) {
+            console.log("데이터가 없습니다.");
+            return;
+        }
+
+        renderVisitorTrend(data);
+        renderHourlyStats(data);
+        renderReservationStats(data);
+        renderMissionStats(data);
+    } catch (err) {
+        console.error("통계 데이터 로드 실패:", err);
+        alert("통계를 불러오는 중 오류가 발생했습니다.");
+    }
+});
+
+function renderVisitorTrend(data) {
+    const loading = document.getElementById('visitorTrend-loading');
+    const canvas = document.getElementById('visitorTrend');
+    if (loading) loading.style.display = 'none';
+    if (canvas) canvas.style.display = 'block';
+
+    const dailyData = data.reduce((acc, item) => {
+        const date = item.date;
+        if (!acc[date]) acc[date] = 0;
+        acc[date] += item.visitorCount || 0;
+        return acc;
+    }, {});
+
+    const labels = Object.keys(dailyData).sort();
+    const counts = labels.map(date => dailyData[date]);
+
+    new Chart(canvas, {
+        type: "line",
+        data: {
+            labels,
+            datasets: [{
+                label: "방문자 수",
+                data: counts,
+                borderColor: "#2563eb",
+                backgroundColor: "rgba(37,99,235,0.2)",
+                fill: true,
+                tension: 0.4
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    callbacks: {
+                        title: (items) => `날짜: ${items[0].label}`,
+                        label: (item) => `방문자 수: ${item.formattedValue} 명`
+                    }
+                }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        stepSize: 1,
+                        callback: (value) => Number.isInteger(value) ? value : null
+                    }
+                }
+            }
+        }
+    });
+}
+
+function renderHourlyStats(data) {
+    const loading = document.getElementById('hourlyStats-loading');
+    const canvas = document.getElementById('hourlyStats');
+    if (loading) loading.style.display = 'none';
+    if (canvas) canvas.style.display = 'block';
+
+    const hourlyData = data.filter(d => d.hour !== null && d.hour !== undefined);
+
+    if (hourlyData.length === 0) {
+        canvas.style.display = 'none';
+        const message = document.createElement('div');
+        message.style.cssText = 'text-align:center; color:#666; padding:40px; font-size:14px;';
+        message.textContent = '시간대별 데이터가 없습니다.';
+        canvas.parentNode.appendChild(message);
+        return;
+    }
+
+    const hourlyGroup = hourlyData.reduce((acc, item) => {
+        const hour = item.hour;
+        if (!acc[hour]) acc[hour] = 0;
+        acc[hour] += item.visitorCount || 0;
+        return acc;
+    }, {});
+
+    const hours = Object.keys(hourlyGroup).sort((a, b) => parseInt(a) - parseInt(b));
+    const labels = hours.map(h => `${h}시`);
+    const counts = hours.map(h => hourlyGroup[h]);
+
+    new Chart(canvas, {
+        type: "bar",
+        data: {
+            labels,
+            datasets: [{
+                label: "시간대별 방문자",
+                data: counts,
+                backgroundColor: ["#2563eb", "#10b981", "#f59e0b", "#a855f7", "#ef4444", "#06b6d4"],
+                borderWidth: 2,
+                borderRadius: 8,
+                borderSkipped: false
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    callbacks: {
+                        title: (items) => `시간대: ${items[0].label}`,
+                        label: (item) => `방문자 수: ${item.formattedValue} 명`
+                    }
+                }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        stepSize: 1,
+                        callback: (value) => Number.isInteger(value) ? value : null
+                    },
+                    grid: { color: 'rgba(0,0,0,0.05)' }
+                },
+                x: { grid: { display: false } }
+            }
+        }
+    });
+}
+
+function renderReservationStats(data) {
+    const loading = document.getElementById('reservationStats-loading');
+    const canvas = document.getElementById('reservationStats');
+    if (loading) loading.style.display = 'none';
+    if (canvas) canvas.style.display = 'block';
+
+    const confirmed = data.reduce((sum, d) => sum + (d.reservationCount || 0), 0);
+    const canceled = data.reduce((sum, d) => sum + (d.canceledCount || 0), 0);
+
+    if (confirmed === 0 && canceled === 0) {
+        canvas.style.display = 'none';
+        const message = document.createElement('div');
+        message.style.cssText = 'text-align:center; color:#666; padding:40px; font-size:14px;';
+        message.textContent = '예약 데이터가 없습니다.';
+        canvas.parentNode.appendChild(message);
+        return;
+    }
+
+    const chartData = [];
+    const chartLabels = [];
+    const chartColors = [];
+
+    if (confirmed > 0) {
+        chartData.push(confirmed);
+        chartLabels.push(`예약 완료`);
+        chartColors.push("#3b82f6");
+    }
+
+    if (canceled > 0) {
+        chartData.push(canceled);
+        chartLabels.push(`취소`);
+        chartColors.push("#ef4444");
+    }
+
+    new Chart(canvas, {
+        type: "doughnut",
+        data: {
+            labels: chartLabels,
+            datasets: [{
+                data: chartData,
+                backgroundColor: chartColors
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    displayColors: false,
+                    callbacks: {
+                        title: (items) => '예약 현황',
+                        label: (item) => `${chartLabels[item.dataIndex]}: ${item.formattedValue} 건`
+                    }
+                }
+            }
+        }
+    });
+}
+
+function renderMissionStats(data) {
+    const loading = document.getElementById('missionStats-loading');
+    const canvas = document.getElementById('missionStats');
+    if (loading) loading.style.display = 'none';
+    if (canvas) canvas.style.display = 'block';
+
+    const missionData = data.reduce((acc, item) => {
+        const date = item.date;
+        if (!acc[date]) acc[date] = 0;
+        acc[date] += item.missionCompletedCount || 0;
+        return acc;
+    }, {});
+
+    const labels = Object.keys(missionData).sort();
+    const counts = labels.map(date => missionData[date]);
+
+    if (labels.length === 0 || counts.every(count => count === 0)) {
+        canvas.style.display = 'none';
+        const message = document.createElement('div');
+        message.style.cssText = 'text-align:center; color:#666; padding:40px; font-size:14px;';
+        message.textContent = '미션 데이터가 없습니다.';
+        canvas.parentNode.appendChild(message);
+        return;
+    }
+
+    new Chart(canvas, {
+        type: "bar",
+        data: {
+            labels,
+            datasets: [{
+                label: "미션 수행자",
+                data: counts,
+                backgroundColor: "#f59e0b"
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    callbacks: {
+                        title: (items) => `날짜: ${items[0].label}`,
+                        label: (item) => `미션 수행자: ${item.formattedValue} 명`
+                    }
+                }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        stepSize: 1,
+                        callback: (value) => Number.isInteger(value) ? value : null
+                    }
+                }
+            }
+        }
+    });
+}

--- a/src/main/resources/static/js/pages.js
+++ b/src/main/resources/static/js/pages.js
@@ -85,6 +85,11 @@ const Pages = {
         }
         window.location.href = `/chat/${reservationId}?token=${encodeURIComponent(token)}`;
     },
+    //팝업 통계 페이지
+    popupStats(popupId) {
+        window.location.href = `/mypage/host/popup/${popupId}/stats`;
+    },
+
 };
 
 // 팝업 상세 페이지로 이동

--- a/src/main/resources/static/templates/pages/mypage/host/popup-stats.html
+++ b/src/main/resources/static/templates/pages/mypage/host/popup-stats.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>팝업 통계</title>
+    <link rel="stylesheet" href="/css/layout.css">
+    <link rel="stylesheet" href="/css/mypage/host/popup-stats.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<div class="mobile-container">
+    <div id="header-container"></div>
+    <main class="main-content" id="main-content">
+        <h3 class="block-title">팝업 통계</h3>
+
+        <div class="block chart-card">
+            <h4>📈 방문자 변동</h4>
+            <div class="loading" id="visitorTrend-loading">데이터를 불러오는 중...</div>
+            <canvas id="visitorTrend" style="display:none;"></canvas>
+        </div>
+
+        <div class="block chart-card">
+            <h4>⏰ 시간대별 분석</h4>
+            <div class="loading" id="hourlyStats-loading">데이터를 불러오는 중...</div>
+            <canvas id="hourlyStats" style="display:none;"></canvas>
+        </div>
+
+        <div class="block chart-card">
+            <h4>📊 예약 현황</h4>
+            <div class="loading" id="reservationStats-loading">데이터를 불러오는 중...</div>
+            <canvas id="reservationStats" style="display:none;"></canvas>
+        </div>
+
+        <div class="block chart-card">
+            <h4>🎯 미션 수행자 수</h4>
+            <div class="loading" id="missionStats-loading">데이터를 불러오는 중...</div>
+            <canvas id="missionStats" style="display:none;"></canvas>
+        </div>
+    </main>
+    <div id="footer-container"></div>
+</div>
+
+<script src="/js/templateLoader.js"></script>
+<script src="/js/api.js"></script>
+<script src="/js/layout.js"></script>
+<script src="/js/pages.js"></script>
+<script src="/js/mypage/host/popup-stats.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', async function() {
+        await loadComponents();
+        initializeLayout();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 Summary
- resolve: #110 
- Related Jira: POP-122

## ✨ Description
팝업 별 통계 제공

## 📸 Screenshot
해당 팝업의 통계 페이지

<img width="605" height="164" alt="image" src="https://github.com/user-attachments/assets/5cff3478-9370-4aa9-acdb-74dd290e1546" />

<img width="607" height="928" alt="image" src="https://github.com/user-attachments/assets/483cc239-cca7-4c8b-ba14-329f192b449e" />

<img width="591" height="753" alt="image" src="https://github.com/user-attachments/assets/8db9f4c5-0774-4293-a1ec-e3e891a01bdb" />

<img width="612" height="529" alt="image" src="https://github.com/user-attachments/assets/23847d4f-462d-4011-beb9-9b2976b7b3e7" />


## 🗒️ Review Point
```
- 현재는 최근 7일을 기준으로 합니다. 기간 설정은 추가 할 수도 있습니다.
```

## ✅ CheckList
- [ ] check 1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a host “Popup Stats” dashboard with interactive charts: daily visitors, hourly traffic, reservation status, and mission completions.
  - Enabled navigation to the stats page from each popup’s “Stats” button in My Page.
  - Provided a backend endpoint to retrieve popup statistics with optional date range.

- Style
  - Introduced responsive styling for the stats dashboard, including loading, empty, and error states for a smoother user experience.

- Chores
  - Added client-side script to fetch stats and render charts with clear messages when data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->