### PR TITLE
feat #POP-128: 상세페이지 지도 구현

### DIFF
--- a/src/main/java/com/snow/popin/domain/popup/controller/PopupController.java
+++ b/src/main/java/com/snow/popin/domain/popup/controller/PopupController.java
@@ -4,8 +4,10 @@ import com.snow.popin.domain.popup.dto.request.PopupListRequestDto;
 import com.snow.popin.domain.popup.dto.request.PopupSearchRequestDto;
 import com.snow.popin.domain.popup.dto.response.PopupDetailResponseDto;
 import com.snow.popin.domain.popup.dto.response.PopupListResponseDto;
+import com.snow.popin.domain.popup.dto.response.PopupSummaryResponseDto;
 import com.snow.popin.domain.popup.service.PopupService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,6 +15,7 @@ import javax.validation.Valid;
 import javax.validation.Validator;
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/popups")
 @RequiredArgsConstructor
@@ -55,6 +58,26 @@ public class PopupController {
         } catch (Exception e) {
             return ResponseEntity.ok(PopupListResponseDto.empty(page, size));
         }
+    }
+
+    // 카테고리별 팝업 조회
+    @GetMapping("/category/{categoryName}")
+    public ResponseEntity<PopupListResponseDto> getPopupsByCategory(
+            @PathVariable String categoryName,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        log.info("카테고리별 팝업 조회 API 호출 - 카테고리: {}, 페이지: {}, 크기: {}", categoryName, page, size);
+        PopupListResponseDto response = popupService.getPopupsByCategory(categoryName, page, size);
+        return ResponseEntity.ok(response);
+    }
+
+    // 지역별 팝업 조회
+    @GetMapping("/region/{region}")
+    public ResponseEntity<List<PopupSummaryResponseDto>> getPopupsByRegion(@PathVariable String region) {
+        log.info("지역별 팝업 조회 API 호출 - 지역: {}", region);
+        List<PopupSummaryResponseDto> popups = popupService.getPopupsByRegion(region);
+        return ResponseEntity.ok(popups);
     }
 
     // 인기 팝업 조회 (isFeatured = true)

--- a/src/main/java/com/snow/popin/domain/popup/controller/PopupController.java
+++ b/src/main/java/com/snow/popin/domain/popup/controller/PopupController.java
@@ -34,6 +34,29 @@ public class PopupController {
         return ResponseEntity.ok(response);
     }
 
+    // 유사한 팝업 조회
+    @GetMapping("/{popupId}/similar")
+    public ResponseEntity<PopupListResponseDto> getSimilarPopups(
+            @PathVariable Long popupId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "4") int size) {
+
+        try {
+            PopupDetailResponseDto currentPopup = popupService.getPopupDetail(popupId);
+
+            if (currentPopup.getCategoryName() == null) {
+                return ResponseEntity.ok(PopupListResponseDto.empty(page, size));
+            }
+
+            PopupListResponseDto response = popupService.getSimilarPopups(
+                    currentPopup.getCategoryName(), popupId, page, size);
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            return ResponseEntity.ok(PopupListResponseDto.empty(page, size));
+        }
+    }
+
     // 인기 팝업 조회 (isFeatured = true)
     @GetMapping("/popular")
     public ResponseEntity<PopupListResponseDto> getPopularPopups(

--- a/src/main/java/com/snow/popin/domain/popup/dto/response/PopupDetailResponseDto.java
+++ b/src/main/java/com/snow/popin/domain/popup/dto/response/PopupDetailResponseDto.java
@@ -36,6 +36,8 @@ public class PopupDetailResponseDto {
     private final String venueName;
     private final String venueAddress;
     private final String region;
+    private Double latitude;
+    private Double longitude;
     private final Boolean parkingAvailable;
 
     private final Long categoryId;
@@ -67,6 +69,8 @@ public class PopupDetailResponseDto {
                 .venueName(popup.getVenueName())
                 .venueAddress(popup.getVenueAddress())
                 .region(popup.getRegion())
+                .latitude(popup.getLatitude())
+                .longitude(popup.getLongitude())
                 .parkingAvailable(popup.getParkingAvailable())
                 .categoryId(popup.getCategory() != null ? popup.getCategory().getId() : null)
                 .categoryName(popup.getCategoryName())

--- a/src/main/java/com/snow/popin/domain/popup/dto/response/PopupListResponseDto.java
+++ b/src/main/java/com/snow/popin/domain/popup/dto/response/PopupListResponseDto.java
@@ -3,7 +3,10 @@ package com.snow.popin.domain.popup.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
+import java.util.Collections;
 import java.util.List;
 
 @Getter
@@ -27,5 +30,29 @@ public class PopupListResponseDto {
                 .hasNext(page.hasNext())
                 .hasPrevious(page.hasPrevious())
                 .build();
+    }
+
+    // 빈 응답을 생성
+    public static PopupListResponseDto empty() {
+        return empty(0, 20); // 기본 페이지 크기
+    }
+
+    // 페이지 정보와 함께 빈 응답을 생성
+    public static PopupListResponseDto empty(int page, int size) {
+        Page<PopupSummaryResponseDto> emptyPage = new PageImpl<>(
+                Collections.emptyList(),
+                PageRequest.of(page, size),
+                0
+        );
+
+        return new PopupListResponseDto(
+                Collections.emptyList(),
+                0,  // totalPages
+                0,  // totalElements
+                page,
+                size,
+                false,  // hasNext
+                false   // hasPrevious
+        );
     }
 }

--- a/src/main/java/com/snow/popin/domain/popup/repository/PopupRepository.java
+++ b/src/main/java/com/snow/popin/domain/popup/repository/PopupRepository.java
@@ -53,8 +53,24 @@ public interface PopupRepository extends JpaRepository<Popup, Long>, JpaSpecific
 
     // 팝업 상세 조회
     @EntityGraph(attributePaths = {"images", "hours", "venue", "tags", "category"})
-    @Query("SELECT p FROM Popup p WHERE p.id = :id")
+    @Query("SELECT p FROM Popup p " +
+            "LEFT JOIN FETCH p.venue v " +
+            "LEFT JOIN FETCH p.category c " +
+            "WHERE p.id = :id")
     Optional<Popup> findByIdWithDetails(@Param("id") Long id);
+
+    // 유사한 팝업 조회
+    @Query("SELECT p FROM Popup p " +
+            "LEFT JOIN FETCH p.venue v " +
+            "LEFT JOIN FETCH p.category c " +
+            "WHERE c.name = :categoryName " +
+            "AND p.id != :excludeId " +
+            "AND (p.status = com.snow.popin.domain.popup.entity.PopupStatus.ONGOING OR " +
+            "     p.status = com.snow.popin.domain.popup.entity.PopupStatus.PLANNED) " +
+            "ORDER BY p.createdAt DESC")
+    Page<Popup> findSimilarPopups(@Param("categoryName") String categoryName,
+                                  @Param("excludeId") Long excludeId,
+                                  Pageable pageable);
 
     // 인기 팝업 조회 (isFeatured = true)
     @Query(value = "SELECT p FROM Popup p LEFT JOIN FETCH p.venue v LEFT JOIN FETCH p.category c " +

--- a/src/main/java/com/snow/popin/domain/popup/repository/PopupRepository.java
+++ b/src/main/java/com/snow/popin/domain/popup/repository/PopupRepository.java
@@ -60,14 +60,20 @@ public interface PopupRepository extends JpaRepository<Popup, Long>, JpaSpecific
     Optional<Popup> findByIdWithDetails(@Param("id") Long id);
 
     // 유사한 팝업 조회
-    @Query("SELECT p FROM Popup p " +
+    @Query(value = "SELECT p FROM Popup p " +
             "LEFT JOIN FETCH p.venue v " +
             "LEFT JOIN FETCH p.category c " +
             "WHERE c.name = :categoryName " +
             "AND p.id != :excludeId " +
             "AND (p.status = com.snow.popin.domain.popup.entity.PopupStatus.ONGOING OR " +
             "     p.status = com.snow.popin.domain.popup.entity.PopupStatus.PLANNED) " +
-            "ORDER BY p.createdAt DESC")
+            "ORDER BY p.createdAt DESC",
+            countQuery = "SELECT count(p) FROM Popup p " +
+                    "LEFT JOIN p.category c " +
+                    "WHERE c.name = :categoryName " +
+                    "AND p.id != :excludeId " +
+                    "AND (p.status = com.snow.popin.domain.popup.entity.PopupStatus.ONGOING OR " +
+                    "     p.status = com.snow.popin.domain.popup.entity.PopupStatus.PLANNED)")
     Page<Popup> findSimilarPopups(@Param("categoryName") String categoryName,
                                   @Param("excludeId") Long excludeId,
                                   Pageable pageable);
@@ -191,4 +197,40 @@ public interface PopupRepository extends JpaRepository<Popup, Long>, JpaSpecific
     // ENDED 상태로 변경되어야 할 ONGOING 상태의 팝업 목록을 조회
     @Query("SELECT p FROM Popup p WHERE p.status = com.snow.popin.domain.popup.entity.PopupStatus.ONGOING AND p.endDate < :today")
     List<Popup> findPopupsToUpdateToEnded(@Param("today") LocalDate today);
+
+    // 카테고리별 팝업 조회 (API에서 사용)
+    @Query(value = "SELECT p FROM Popup p " +
+            "LEFT JOIN FETCH p.venue v " +
+            "LEFT JOIN FETCH p.category c " +
+            "WHERE (:categoryName IS NULL OR c.name = :categoryName) " +
+            "AND (p.status = com.snow.popin.domain.popup.entity.PopupStatus.ONGOING OR " +
+            "     p.status = com.snow.popin.domain.popup.entity.PopupStatus.PLANNED) " +
+            "ORDER BY p.createdAt DESC",
+            countQuery = "SELECT count(p) FROM Popup p " +
+                    "LEFT JOIN p.category c " +
+                    "WHERE (:categoryName IS NULL OR c.name = :categoryName) " +
+                    "AND (p.status = com.snow.popin.domain.popup.entity.PopupStatus.ONGOING OR " +
+                    "     p.status = com.snow.popin.domain.popup.entity.PopupStatus.PLANNED)")
+    Page<Popup> findByCategoryName(@Param("categoryName") String categoryName, Pageable pageable);
+
+    // 위치 정보가 있는 팝업만 조회 (지도용)
+    @Query("SELECT p FROM Popup p " +
+            "LEFT JOIN FETCH p.venue v " +
+            "LEFT JOIN FETCH p.category c " +
+            "WHERE v.latitude IS NOT NULL " +
+            "AND v.longitude IS NOT NULL " +
+            "AND (p.status = com.snow.popin.domain.popup.entity.PopupStatus.ONGOING OR " +
+            "     p.status = com.snow.popin.domain.popup.entity.PopupStatus.PLANNED) " +
+            "ORDER BY p.createdAt DESC")
+    List<Popup> findPopupsWithLocation();
+
+    // 특정 지역의 팝업 조회
+    @Query("SELECT p FROM Popup p " +
+            "LEFT JOIN FETCH p.venue v " +
+            "LEFT JOIN FETCH p.category c " +
+            "WHERE v.region = :region " +
+            "AND (p.status = com.snow.popin.domain.popup.entity.PopupStatus.ONGOING OR " +
+            "     p.status = com.snow.popin.domain.popup.entity.PopupStatus.PLANNED) " +
+            "ORDER BY p.createdAt DESC")
+    List<Popup> findByRegion(@Param("region") String region);
 }

--- a/src/main/java/com/snow/popin/domain/popup/service/PopupService.java
+++ b/src/main/java/com/snow/popin/domain/popup/service/PopupService.java
@@ -58,6 +58,21 @@ public class PopupService {
         return PopupDetailResponseDto.from(popup);
     }
 
+    // 유사한 팝업 조회
+    public PopupListResponseDto getSimilarPopups(String categoryName, Long excludePopupId, int page, int size) {
+        log.info("유사한 팝업 조회 - 카테고리: {}, 제외 ID: {}", categoryName, excludePopupId);
+
+        Pageable pageable = createPageable(page, size);
+        Page<Popup> popupPage = popupRepository.findSimilarPopups(categoryName, excludePopupId, pageable);
+
+        List<PopupSummaryResponseDto> popupDtos = popupPage.getContent()
+                .stream()
+                .map(PopupSummaryResponseDto::from)
+                .collect(Collectors.toList());
+
+        return PopupListResponseDto.of(popupPage, popupDtos);
+    }
+
     // 인기 팝업 조회 (isFeatured = true)
     public PopupListResponseDto getPopularPopups(int page, int size) {
         log.info("인기 팝업 조회 시작 - page: {}, size: {}", page, size);

--- a/src/main/java/com/snow/popin/domain/popup/service/PopupService.java
+++ b/src/main/java/com/snow/popin/domain/popup/service/PopupService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -62,15 +63,69 @@ public class PopupService {
     public PopupListResponseDto getSimilarPopups(String categoryName, Long excludePopupId, int page, int size) {
         log.info("유사한 팝업 조회 - 카테고리: {}, 제외 ID: {}", categoryName, excludePopupId);
 
-        Pageable pageable = createPageable(page, size);
-        Page<Popup> popupPage = popupRepository.findSimilarPopups(categoryName, excludePopupId, pageable);
+        if (categoryName == null || categoryName.trim().isEmpty()) {
+            log.warn("카테고리명이 없어서 빈 결과를 반환합니다.");
+            return PopupListResponseDto.empty();
+        }
 
-        List<PopupSummaryResponseDto> popupDtos = popupPage.getContent()
-                .stream()
-                .map(PopupSummaryResponseDto::from)
-                .collect(Collectors.toList());
+        try {
+            Pageable pageable = createPageable(page, size);
+            Page<Popup> popupPage = popupRepository.findSimilarPopups(categoryName, excludePopupId, pageable);
 
-        return PopupListResponseDto.of(popupPage, popupDtos);
+            List<PopupSummaryResponseDto> popupDtos = popupPage.getContent()
+                    .stream()
+                    .map(PopupSummaryResponseDto::from)
+                    .collect(Collectors.toList());
+
+            log.info("유사한 팝업 조회 완료 - 총 {}개", popupPage.getTotalElements());
+            return PopupListResponseDto.of(popupPage, popupDtos);
+
+        } catch (Exception e) {
+            log.error("유사한 팝업 조회 실패 - 카테고리: {}, 오류: {}", categoryName, e.getMessage());
+            return PopupListResponseDto.empty();
+        }
+    }
+
+    // 카테고리별 팝업 조회
+    public PopupListResponseDto getPopupsByCategory(String categoryName, int page, int size) {
+        log.info("카테고리별 팝업 조회 - 카테고리: {}", categoryName);
+
+        try {
+            Pageable pageable = createPageable(page, size);
+            Page<Popup> popupPage = popupRepository.findByCategoryName(categoryName, pageable);
+
+            List<PopupSummaryResponseDto> popupDtos = popupPage.getContent()
+                    .stream()
+                    .map(PopupSummaryResponseDto::from)
+                    .collect(Collectors.toList());
+
+            log.info("카테고리별 팝업 조회 완료 - 총 {}개", popupPage.getTotalElements());
+            return PopupListResponseDto.of(popupPage, popupDtos);
+
+        } catch (Exception e) {
+            log.error("카테고리별 팝업 조회 실패 - 카테고리: {}, 오류: {}", categoryName, e.getMessage());
+            return PopupListResponseDto.empty();
+        }
+    }
+
+    // 지역별 팝업 조회
+    public List<PopupSummaryResponseDto> getPopupsByRegion(String region) {
+        log.info("지역별 팝업 조회 - 지역: {}", region);
+
+        try {
+            List<Popup> popups = popupRepository.findByRegion(region);
+
+            List<PopupSummaryResponseDto> result = popups.stream()
+                    .map(PopupSummaryResponseDto::from)
+                    .collect(Collectors.toList());
+
+            log.info("지역별 팝업 조회 완료 - 총 {}개", result.size());
+            return result;
+
+        } catch (Exception e) {
+            log.error("지역별 팝업 조회 실패 - 지역: {}, 오류: {}", region, e.getMessage());
+            return Collections.emptyList();
+        }
     }
 
     // 인기 팝업 조회 (isFeatured = true)

--- a/src/main/resources/static/css/popup-detail.css
+++ b/src/main/resources/static/css/popup-detail.css
@@ -141,13 +141,14 @@
     display: flex;
     align-items: center;
     margin-bottom: 16px;
+    gap: 6px;
 }
 
 .location-header svg {
     width: 20px;
     height: 20px;
     color: #6366F1;
-    margin-right: 8px;
+    flex-shrink: 0;
 }
 
 .location-title {
@@ -158,10 +159,18 @@
 }
 
 .venue-name {
-    font-size: 16px;
+    font-size: 18px;
     font-weight: 600;
     color: #333;
-    padding-bottom: 16px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.venue-name::before {
+    content: '-';
+    margin-right: 8px;
+    color: #333;
 }
 
 .map-container {

--- a/src/main/resources/static/css/popup-detail.css
+++ b/src/main/resources/static/css/popup-detail.css
@@ -228,6 +228,28 @@
     display: none;
 }
 
+.toast {
+    visibility: hidden;
+    min-width: 250px;
+    background-color: #333;
+    color: #fff;
+    text-align: center;
+    border-radius: 8px;
+    padding: 16px;
+    position: fixed;
+    z-index: 9999;
+    left: 50%;
+    bottom: 50px;
+    transform: translateX(-50%);
+    opacity: 0;
+    transition: visibility 0.5s, opacity 0.5s linear;
+}
+
+.toast.show {
+    visibility: visible;
+    opacity: 1;
+}
+
 /* 리뷰 섹션 */
 .reviews-section {
     padding: 24px 20px;

--- a/src/main/resources/static/css/popup-detail.css
+++ b/src/main/resources/static/css/popup-detail.css
@@ -129,6 +129,105 @@
     background: #5856F0;
 }
 
+/* 위치 섹션 */
+.location-section {
+    margin: 20px 0;
+    padding: 20px;
+    background: #fff;
+    border-bottom: 8px solid #F8F9FA;
+}
+
+.location-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.location-header svg {
+    width: 20px;
+    height: 20px;
+    color: #6366F1;
+    margin-right: 8px;
+}
+
+.location-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1F2937;
+    margin: 0;
+}
+
+.venue-name {
+    font-size: 16px;
+    font-weight: 600;
+    color: #333;
+    padding-bottom: 16px;
+}
+
+.map-container {
+    width: 100%;
+    height: 300px;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid #E5E7EB;
+    margin-bottom: 12px;
+}
+
+#popup-location-map {
+    width: 100%;
+    height: 100%;
+}
+
+.address-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 0;
+    border-top: 1px solid #F3F4F6;
+}
+
+.venue-address-inline {
+    flex: 1;
+    font-size: 14px;
+    color: #374151;
+    line-height: 1.4;
+}
+
+.copy-btn-inline {
+    flex-shrink: 0;
+    padding: 8px 16px;
+    background: #6366F1;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+}
+
+.copy-btn-inline:hover {
+    background: #5856F0;
+    transform: translateY(-1px);
+}
+
+.copy-btn-inline.copied {
+    background: #10B981;
+}
+
+.venue-address {
+    display: none;
+}
+
+.address-actions {
+    display: none;
+}
+
+.copy-btn {
+    display: none;
+}
+
 /* 리뷰 섹션 */
 .reviews-section {
     padding: 24px 20px;
@@ -478,5 +577,21 @@
         width: 100%;
         padding: 12px;
         border-radius: 8px;
+    }
+}
+
+@media (max-width: 768px) {
+    .map-container {
+        height: 250px;
+    }
+
+    .address-row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 8px;
+    }
+
+    .copy-btn-inline {
+        text-align: center;
     }
 }

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -376,7 +376,7 @@ apiService.getReservationStats = async function() {
 
 // === 팝업 관련 API ===
 
-// 팝업 목록 조회 - 실제 API 호출
+// 팝업 목록 조회
 apiService.getPopups = async function(params = {}) {
     const sp = new URLSearchParams();
 

--- a/src/main/resources/static/js/popup-detail.js
+++ b/src/main/resources/static/js/popup-detail.js
@@ -234,9 +234,6 @@ class PopupDetailManager {
 
             this.locationMap = new kakao.maps.Map(mapContainer, mapOption);
 
-            this.locationMap.relayout();
-            this.locationMap.setCenter(mapOption.center);
-
             const mapCreateEnd = performance.now();
             console.log(`[지도 초기화] 지도 생성 완료 (소요시간: ${mapCreateEnd - mapCreateStart}ms)`);
 
@@ -480,6 +477,13 @@ class PopupDetailManager {
         document.getElementById('popup-detail-content').style.display = 'block';
         if (document.getElementById('popup-detail-error')) {
             document.getElementById('popup-detail-error').style.display = 'none';
+        }
+
+        if (this.locationMap) {
+            this.locationMap.relayout();
+
+            const correctPosition = new kakao.maps.LatLng(this.popupData.latitude, this.popupData.longitude);
+            this.locationMap.setCenter(correctPosition);
         }
     }
 

--- a/src/main/resources/static/js/popup-detail.js
+++ b/src/main/resources/static/js/popup-detail.js
@@ -179,7 +179,9 @@ class PopupDetailManager {
         }
 
         if (hasLocation) {
-            this.initializeLocationMap();
+            setTimeout(() => {
+                this.initializeLocationMap();
+            }, 0);
         } else {
             const mapContainer = document.querySelector('.map-container');
             if (mapContainer) {
@@ -231,6 +233,9 @@ class PopupDetailManager {
             console.log('[지도 초기화] 지도 생성 시작');
 
             this.locationMap = new kakao.maps.Map(mapContainer, mapOption);
+
+            this.locationMap.relayout();
+            this.locationMap.setCenter(mapOption.center);
 
             const mapCreateEnd = performance.now();
             console.log(`[지도 초기화] 지도 생성 완료 (소요시간: ${mapCreateEnd - mapCreateStart}ms)`);

--- a/src/main/resources/static/templates/pages/popup/popup-detail.html
+++ b/src/main/resources/static/templates/pages/popup/popup-detail.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title id="page-title">POPIN - 팝업 상세</title>
 
+    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=eaef006c7d0c88e0935a7d8745e99144"></script>
+
     <!-- 공통 레이아웃 CSS -->
     <link rel="stylesheet" href="/css/layout.css">
     <link rel="stylesheet" href="/css/popup-detail.css">
@@ -65,6 +67,33 @@
                 <button id="reservation-btn" class="reservation-btn">
                     예약하기
                 </button>
+            </div>
+
+            <!-- 지도 섹션 -->
+            <div class="location-section" id="location-section" style="display: none;">
+                <div class="location-header">
+                    <svg viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+                    </svg>
+                    <h2 class="location-title">위치</h2>
+                </div>
+
+                <div class="venue-info">
+                    <div id="venue-name" class="venue-name"></div>
+                </div>
+
+                <!-- 지도 -->
+                <div class="map-container">
+                    <div id="popup-location-map"></div>
+                </div>
+
+                <!-- 주소 복사 버튼 -->
+                <div class="address-row">
+                    <div id="venue-address" class="venue-address-inline"></div>
+                    <button id="copy-address-btn" class="copy-btn-inline">
+                        주소복사
+                    </button>
+                </div>
             </div>
 
             <!-- 리뷰 섹션 -->

--- a/src/main/resources/static/templates/pages/popup/popup-detail.html
+++ b/src/main/resources/static/templates/pages/popup/popup-detail.html
@@ -76,9 +76,6 @@
                         <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
                     </svg>
                     <h2 class="location-title">위치</h2>
-                </div>
-
-                <div class="venue-info">
                     <div id="venue-name" class="venue-name"></div>
                 </div>
 


### PR DESCRIPTION
## 📌 Summary
- resolve: #121 
- Related Jira: POP-128

## ✨ Description
<!-- 변경 사항 요약 -->
### 상세페이지에 나타날 지도 구현
- 상세페이지에 팝업의 위치를 확인할 수 있도록 지도를 추가했습니다.
- 밑에 주소 복사 버튼을 클릭하면 주소가 복사됩니다.

## 📸 Screenshot
<!-- UI 변화가 없다면 지워주세요 -->
|기능|스크린샷|
|:--:|:--:|
|상세페이지|<img src="https://github.com/user-attachments/assets/6cc1c722-b4bb-4433-aaeb-a0d4d7f41935" width="500" />|
|주소복사|<img src="https://github.com/user-attachments/assets/c4893371-a961-4614-ad5c-9a5dbe767737" width="500" />|

## 🗒️ Review Point
```
현재 금일 지도 호출량이 초과되어 화면에 나타나지 않고 있습니다. 
정상적으로 작동하는것을 확인하였습니다!!

길찾기 기능은 현재 우선순위가 낮기 때문에 추후 진행에 따라 추가 구현하겠습니다.
```

## ✅ CheckList
- [ ] 지도
- [ ] 주소 복사