### PR TITLE
design #POP-135: 팝업 상세페이지 정보 표시

### DIFF
--- a/src/main/java/com/snow/popin/domain/popup/dto/response/PopupDetailResponseDto.java
+++ b/src/main/java/com/snow/popin/domain/popup/dto/response/PopupDetailResponseDto.java
@@ -2,6 +2,7 @@ package com.snow.popin.domain.popup.dto.response;
 
 import com.snow.popin.domain.popup.entity.Popup;
 import com.snow.popin.domain.popup.entity.PopupStatus;
+import com.snow.popin.domain.popup.entity.Tag;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,6 +17,7 @@ public class PopupDetailResponseDto {
     private final Long id;
     private final String title;
     private final String summary;
+    private final String description;
     private final LocalDate startDate;
     private final LocalDate endDate;
     private final String periodText;
@@ -46,12 +48,14 @@ public class PopupDetailResponseDto {
 
     private List<PopupImageResponseDto> images;
     private List<PopupHoursResponseDto> hours;
+    private final List<String> tags;
 
     public static PopupDetailResponseDto from(Popup popup) {
         return PopupDetailResponseDto.builder()
                 .id(popup.getId())
                 .title(popup.getTitle())
                 .summary(popup.getSummary())
+                .description(popup.getDescription())
                 .startDate(popup.getStartDate())
                 .endDate(popup.getEndDate())
                 .periodText(popup.getPeriodText())
@@ -80,6 +84,9 @@ public class PopupDetailResponseDto {
                         .collect(Collectors.toList()))
                 .hours(popup.getHours().stream()
                         .map(PopupHoursResponseDto::from)
+                        .collect(Collectors.toList()))
+                .tags(popup.getTags().stream()
+                        .map(Tag::getName)
                         .collect(Collectors.toList()))
                 .build();
     }

--- a/src/main/resources/static/css/popup-detail.css
+++ b/src/main/resources/static/css/popup-detail.css
@@ -71,6 +71,24 @@
     background: #E5E7EB;
 }
 
+/* 운영시간 섹션 */
+.operating-hours-section {
+    padding: 20px;
+    background: #fff;
+    position: relative;
+}
+
+/* 운영시간 섹션 구분선 */
+.operating-hours-section::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 20px;
+    right: 20px;
+    height: 1px;
+    background: #E5E7EB;
+}
+
 .popup-title {
     font-size: 24px;
     font-weight: 700;

--- a/src/main/resources/static/css/popup-detail.css
+++ b/src/main/resources/static/css/popup-detail.css
@@ -57,34 +57,82 @@
 /* 팝업 정보 섹션 */
 .popup-info-section {
     padding: 24px 20px;
-    border-bottom: 8px solid #F8F9FA;
+    position: relative;
+}
+
+/* 양옆 패딩이 있는 구분선 추가 */
+.popup-info-section::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 20px;
+    right: 20px;
+    height: 1px;
+    background: #E5E7EB;
 }
 
 .popup-title {
     font-size: 24px;
     font-weight: 700;
     color: #1F2937;
-    margin: 0 0 16px 0;
+    margin: 0 0 20px 0;
     line-height: 1.3;
 }
 
-.popup-dates {
-    margin-bottom: 16px;
+/* 일정 정보 스타일 */
+.popup-schedule-simple {
+    margin-bottom: 20px;
 }
 
-.date-info {
-    margin-bottom: 8px;
+.schedule-item {
+    font-size: 16px;
+    color: #000000;
+    margin-bottom: 4px;
+    line-height: 1.4;
+}
+
+.schedule-item:last-child {
+    margin-bottom: 0;
 }
 
 .period-text {
-    font-size: 16px;
     font-weight: 600;
-    color: #6366F1;
+    color: #000000;
 }
 
-.hours-info {
-    color: #6B7280;
+.days-text {
+    font-weight: 400;
+    color: #000000;
+}
+
+.hours-text {
+    font-weight: 400;
+    color: #000000;
+}
+
+/* 상세 운영시간 스타일 */
+.operating-hours-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #000000;
+    margin-bottom: 12px;
+}
+
+.operating-hours-details {
+    background: #F8F9FA;
+    border-radius: 8px;
+    padding: 16px;
+}
+
+.hours-line {
     font-size: 14px;
+    color: #374151;
+    padding: 4px 0;
+    line-height: 1.4;
+}
+
+.hours-line:last-child {
+    padding-bottom: 0;
 }
 
 .popup-tags {
@@ -131,16 +179,26 @@
 
 /* 위치 섹션 */
 .location-section {
-    margin: 20px 0;
     padding: 20px;
     background: #fff;
-    border-bottom: 8px solid #F8F9FA;
+    position: relative;
+}
+
+/* 위치 섹션 구분선 */
+.location-section::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 20px;
+    right: 20px;
+    height: 1px;
+    background: #E5E7EB;
 }
 
 .location-header {
     display: flex;
     align-items: center;
-    margin-bottom: 16px;
+    margin-bottom: 18px;
     gap: 6px;
 }
 
@@ -179,7 +237,7 @@
     border-radius: 8px;
     overflow: hidden;
     border: 1px solid #E5E7EB;
-    margin-bottom: 12px;
+    margin-bottom: 8px;
 }
 
 #popup-location-map {
@@ -191,8 +249,7 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 12px 0;
-    border-top: 1px solid #F3F4F6;
+    padding: 12px 1px;
 }
 
 .venue-address-inline {
@@ -237,6 +294,59 @@
     display: none;
 }
 
+/* 상세설명 섹션 */
+.description-section {
+    padding: 24px 20px;
+    background: #fff;
+    position: relative;
+}
+
+/* 상세설명 섹션 구분선 */
+.description-section::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 20px;
+    right: 20px;
+    height: 1px;
+    background: #E5E7EB;
+}
+
+.description-section .section-title {
+    font-size: 20px;
+    font-weight: 700;
+    color: #1F2937;
+    margin: 0 0 20px 0;
+}
+
+.description-content {
+    padding: 8px;
+}
+
+.popup-summary {
+    margin-bottom: 20px;
+}
+
+.popup-summary:last-child {
+    margin-bottom: 0;
+}
+
+.description-text {
+    font-size: 14px;
+    line-height: 1.6;
+    color: #6B7280;
+    margin: 0;
+    white-space: pre-wrap;
+}
+
+.description-text p {
+    margin: 0 0 12px 0;
+}
+
+.description-text p:last-child {
+    margin-bottom: 0;
+}
+
 .toast {
     visibility: hidden;
     min-width: 250px;
@@ -262,7 +372,18 @@
 /* 리뷰 섹션 */
 .reviews-section {
     padding: 24px 20px;
-    border-bottom: 8px solid #F8F9FA;
+    position: relative;
+}
+
+/* 리뷰 섹션 구분선 */
+.reviews-section::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 20px;
+    right: 20px;
+    height: 1px;
+    background: #E5E7EB;
 }
 
 .section-header {
@@ -472,6 +593,8 @@
     padding: 24px 20px;
 }
 
+/* 마지막 섹션은 구분선 없음 */
+
 .section-title {
     font-size: 20px;
     font-weight: 700;
@@ -480,9 +603,27 @@
 }
 
 .similar-popups-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    display: flex;
     gap: 16px;
+    overflow-x: auto;
+    padding: 0 0 20px 0;
+    white-space: nowrap;
+    cursor: grab;
+    user-select: none;
+    -webkit-overflow-scrolling: touch;
+}
+
+.similar-popups-grid.active-drag {
+    cursor: grabbing;
+}
+
+.similar-popups-grid::-webkit-scrollbar {
+    display: none;
+}
+
+.similar-popups-grid {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
 }
 
 .similar-popup-card {
@@ -492,6 +633,9 @@
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     cursor: pointer;
     transition: transform 0.2s;
+    flex-shrink: 0;
+    width: 200px;
+    min-width: 200px;
 }
 
 .similar-popup-card:hover {
@@ -593,6 +737,22 @@
         font-size: 22px;
     }
 
+    .schedule-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+    }
+
+    .schedule-label {
+        min-width: auto;
+        margin-right: 0;
+        font-size: 13px;
+    }
+
+    .schedule-value {
+        font-size: 15px;
+    }
+
     .similar-popups-grid {
         grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
         gap: 12px;
@@ -609,9 +769,7 @@
         padding: 12px;
         border-radius: 8px;
     }
-}
 
-@media (max-width: 768px) {
     .map-container {
         height: 250px;
     }
@@ -624,5 +782,23 @@
 
     .copy-btn-inline {
         text-align: center;
+    }
+
+    .description-section {
+        padding: 20px 16px;
+    }
+
+    .popup-schedule-info,
+    .description-content {
+        padding: 16px;
+    }
+
+    /* 모바일에서도 구분선 패딩 조정 */
+    .popup-info-section::after,
+    .location-section::after,
+    .description-section::after,
+    .reviews-section::after {
+        left: 16px;
+        right: 16px;
     }
 }

--- a/src/main/resources/static/js/popup-detail.js
+++ b/src/main/resources/static/js/popup-detail.js
@@ -100,6 +100,7 @@ class PopupDetailManager {
         try {
             this.popupData = await apiService.getPopup(this.popupId);
             this.renderPopupInfo();
+            this.renderOperatingHours();
             this.renderLocationInfo();
             this.renderDescriptionInfo();
             await this.loadSimilarPopups();
@@ -171,51 +172,46 @@ class PopupDetailManager {
                 periodEl.textContent = `${startDate} ~ ${endDate}`;
             }
         }
-
-        // 운영 요일 및 시간 표시
-        if (this.popupData.hours && this.popupData.hours.length > 0) {
-            this.renderOperatingHours();
-        }
     }
 
-    // 운영 시간 렌더링
+    // 운영시간 렌더링
     renderOperatingHours() {
-        const hours = this.popupData.hours;
-
-        // 운영 요일 표시
-        const daysEl = document.getElementById('popup-days');
-        if (daysEl) {
-            daysEl.style.display = 'none';
+        if (!this.popupData || !this.popupData.hours || this.popupData.hours.length === 0) {
+            return;
         }
 
-        // 운영시간 표시를 상세 버전으로 변경
+        const operatingHoursSection = document.getElementById('operating-hours-section');
         const hoursEl = document.getElementById('popup-hours');
 
-        if (hoursEl && hours.length > 0) {
-            hoursEl.style.display = 'block';
+        if (!operatingHoursSection || !hoursEl) return;
 
-            // 요일별 운영시간 상세 표시
-            const detailedHours = hours.map(hour => {
-                const dayText = hour.dayOfWeekText;
-                const timeText = hour.timeRangeText.replace(' - ', ' - ');
+        // 운영시간 섹션 표시
+        operatingHoursSection.style.display = 'block';
 
-                // 특별 운영시간이나 휴무일 체크
-                let timeDisplay = timeText;
-                if (hour.note) {
-                    timeDisplay += ` (${hour.note})`;
-                }
+        const hours = this.popupData.hours;
 
-                return `${dayText} : ${timeDisplay}`;
-            }).join('\n');
+        // 요일별 운영시간 상세 표시
+        const detailedHours = hours.map(hour => {
+            const dayText = hour.dayOfWeekText;
+            const timeText = hour.timeRangeText.replace(' - ', ' - ');
 
-            // 운영시간 제목과 상세 내용을 함께 표시
-            hoursEl.innerHTML = `
-                <div class="operating-hours-title">운영 시간</div>
-                <div class="operating-hours-details">${detailedHours.split('\n').map(line =>
-                `<div class="hours-line">${line}</div>`
-            ).join('')}</div>
-            `;
-        }
+            // 특별 운영시간이나 휴무일 체크
+            let timeDisplay = timeText;
+            if (hour.note) {
+                timeDisplay += ` (${hour.note})`;
+            }
+
+            return `${dayText} : ${timeDisplay}`;
+        }).join('\n');
+
+        // 운영시간 내용 표시
+        hoursEl.innerHTML = `
+            <div class="operating-hours-details">${detailedHours.split('\n').map(line =>
+            `<div class="hours-line">${line}</div>`
+        ).join('')}</div>
+        `;
+
+        hoursEl.style.display = 'block';
     }
 
     // 위치 정보 렌더링 메서드

--- a/src/main/resources/static/templates/pages/popup/popup-detail.html
+++ b/src/main/resources/static/templates/pages/popup/popup-detail.html
@@ -66,13 +66,11 @@
             <div class="popup-info-section">
                 <h1 id="popup-title" class="popup-title"></h1>
 
-                <div class="popup-dates">
-                    <div class="date-info">
-                        <span id="popup-period" class="period-text"></span>
-                    </div>
-                    <div class="hours-info">
-                        <div id="popup-hours" class="hours-text"></div>
-                    </div>
+                <!-- 기간 및 일정 정보 -->
+                <div class="popup-schedule-simple">
+                    <div id="popup-period" class="schedule-item period-text"></div>
+                    <div id="popup-days" class="schedule-item days-text" style="display: none;"></div>
+                    <div id="popup-hours" class="schedule-item hours-text" style="display: none;"></div>
                 </div>
 
                 <!-- 태그 섹션 -->
@@ -105,6 +103,15 @@
                     <button id="copy-address-btn" class="copy-btn-inline">
                         주소복사
                     </button>
+                </div>
+            </div>
+
+            <!-- 팝업 상세설명 섹션 -->
+            <div class="description-section" id="description-section" style="display: none;">
+                <h2 class="section-title">팝업스토어 소개</h2>
+                <div class="description-content">
+                    <div id="popup-summary" class="popup-summary"></div>
+                    <div id="popup-description" class="popup-description"></div>
                 </div>
             </div>
 

--- a/src/main/resources/static/templates/pages/popup/popup-detail.html
+++ b/src/main/resources/static/templates/pages/popup/popup-detail.html
@@ -66,11 +66,10 @@
             <div class="popup-info-section">
                 <h1 id="popup-title" class="popup-title"></h1>
 
-                <!-- 기간 및 일정 정보 -->
+                <!-- 기간 정보 -->
                 <div class="popup-schedule-simple">
                     <div id="popup-period" class="schedule-item period-text"></div>
                     <div id="popup-days" class="schedule-item days-text" style="display: none;"></div>
-                    <div id="popup-hours" class="schedule-item hours-text" style="display: none;"></div>
                 </div>
 
                 <!-- 태그 섹션 -->
@@ -82,12 +81,15 @@
                 </button>
             </div>
 
+            <!-- 운영시간 섹션 -->
+            <div class="operating-hours-section" id="operating-hours-section" style="display: none;">
+                <h2 class="section-title">운영 시간</h2>
+                <div id="popup-hours" class="schedule-item hours-text" style="display: none;"></div>
+            </div>
+
             <!-- 지도 섹션 -->
             <div class="location-section" id="location-section" style="display: none;">
                 <div class="location-header">
-                    <svg viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
-                    </svg>
                     <h2 class="location-title">위치</h2>
                     <div id="venue-name" class="venue-name"></div>
                 </div>


### PR DESCRIPTION
## 📌 Summary
- resolve: #131 
- Related Jira: POP-135

## ✨ Description
<!-- 변경 사항 요약 -->
- 팝업 상세페에지에 보여질 정보들을 화면에 나타나게 했습니다.
- 기존 운영시간은 진행 기간 바로 밑에 위치하였으나, 팝업데이터를 찾던 중 요일별로 운영 시간이 다를 수 있다는 점을 확인하고 section을 따로 분리해 요일별로 운영시간을 확인할 수 있도록 했습니다.

## 📸 Screenshot
<!-- UI 변화가 없다면 지워주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src="https://github.com/user-attachments/assets/088e6aaa-85a3-4505-9b5c-02151f697d99" width="500" />|

## 🗒️ Review Point
```
디자인 수정 필요한 부분 있으면 의견 남겨주세요!!
```

## ✅ CheckList
- [ ] 데이터 표시
- [ ] UI 수정
