### PR TITLE
feat #POP-134: 에러페이지 추가

### DIFF
--- a/src/main/java/com/snow/popin/domain/mission/service/UserMissionService.java
+++ b/src/main/java/com/snow/popin/domain/mission/service/UserMissionService.java
@@ -143,7 +143,4 @@ public class UserMissionService {
 
         return result;
     }
-
-
-
 }

--- a/src/main/java/com/snow/popin/domain/popup/dto/response/PopupBasicResponseDto.java
+++ b/src/main/java/com/snow/popin/domain/popup/dto/response/PopupBasicResponseDto.java
@@ -19,6 +19,7 @@ public class PopupBasicResponseDto {
     private final LocalDate startDate;
     private final LocalDate endDate;
     private final String periodText;
+    private final String status;
 
     public static PopupBasicResponseDto from(Popup popup) {
         return PopupBasicResponseDto.builder()
@@ -31,6 +32,7 @@ public class PopupBasicResponseDto {
                 .startDate(popup.getStartDate())
                 .endDate(popup.getEndDate())
                 .periodText(formatPeriod(popup.getStartDate(), popup.getEndDate()))
+                .status(popup.getStatus().name())
                 .build();
     }
 

--- a/src/main/java/com/snow/popin/global/config/SecurityConfig.java
+++ b/src/main/java/com/snow/popin/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring()
                 .antMatchers("/css/**", "/js/**", "/images/**", "/static/**",
-                        "/favicon.ico", "/templates/**", "/uploads/**");
+                        "/favicon.ico", "/templates/**", "/uploads/**", "/error/**");
     }
 
     @Bean
@@ -57,10 +57,10 @@ public class SecurityConfig {
 
                 .authorizeRequests(authz -> authz
                         // 정적 리소스
-                        .antMatchers("/uploads/**","/css/**", "/js/**", "/images/**", "/static/**", "/favicon.ico", "/templates/**", "/*.json", "/pages/**").permitAll()
+                        .antMatchers("/uploads/**","/css/**", "/js/**", "/images/**", "/static/**", "/favicon.ico", "/templates/**", "/*.json", "/pages/**", "/error/**").permitAll()
 
                         // 공개 페이지
-                        .antMatchers("/", "/index.html", "/main", "/error").permitAll()
+                        .antMatchers("/", "/index.html", "/main").permitAll()
                         .antMatchers("/popup/**", "/map", "/users/**", "/mypage/**", "/space/**", "/missions/**" ,"/reviews/**", "/bookmarks/**").permitAll()
 
 
@@ -94,6 +94,8 @@ public class SecurityConfig {
 
                         .antMatchers("/api/public/**").permitAll()
                         .antMatchers("/api/**").permitAll()
+                        .antMatchers("/not-exist-page").permitAll()   // 테스트용
+
 
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/snow/popin/global/error/BaseErrorController.java
+++ b/src/main/java/com/snow/popin/global/error/BaseErrorController.java
@@ -23,7 +23,7 @@ public class BaseErrorController implements ErrorController {
         ErrorCode errorCode = ErrorCode.fromHttpStatus(httpStatus);
 
         return new ModelAndView(
-                "error",
+                "error/error",
                 Map.of(
                         "statusCode", httpStatus.value(),
                         "errorCode", errorCode,

--- a/src/main/java/com/snow/popin/global/error/BaseExceptionHandler.java
+++ b/src/main/java/com/snow/popin/global/error/BaseExceptionHandler.java
@@ -35,7 +35,7 @@ public class BaseExceptionHandler {
 
     private ModelAndView createErrorView(HttpStatus httpStatus, ErrorCode errorCode, String message) {
         return new ModelAndView(
-                "error",
+                "error/error",
                 Map.of(
                         "statusCode", httpStatus.value(),
                         "errorCode", errorCode,

--- a/src/main/resources/static/error/error.html
+++ b/src/main/resources/static/error/error.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>오류 발생</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background-color: #f5f5f5;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    }
+    .error-container {
+      background: #fff;
+      padding: 40px 32px;
+      border-radius: 16px;
+      box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+      text-align: center;
+      max-width: 480px;
+      width: 100%;
+    }
+    .error-container h1 {
+      font-size: 28px;
+      font-weight: 700;
+      color: #1f2937;
+      margin-bottom: 20px;
+    }
+    .error-container p {
+      font-size: 18px;
+      color: #374151;
+      margin-bottom: 16px;
+      line-height: 1.5;
+    }
+    .btn-home {
+      display: inline-block;
+      margin-top: 16px;
+      padding: 14px 28px;
+      font-size: 16px;
+      font-weight: 600;
+      border-radius: 10px;
+      background: #4B5AE4;
+      color: white;
+      text-decoration: none;
+      transition: background 0.2s;
+    }
+    .btn-home:hover {
+      background: #5855eb;
+    }
+  </style>
+</head>
+<body>
+<div class="error-container">
+  <h1>죄송합니다, 오류가 발생했습니다.</h1>
+  <p id="error-msg"></p>
+  <a href="/" class="btn-home">메인으로 돌아가기</a>
+</div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    const code = sessionStorage.getItem("errorCode");
+    const msgEl = document.getElementById("error-msg");
+
+    if (code === "404") {
+      msgEl.innerText = "요청하신 페이지를 찾을 수 없습니다.";
+    } else if (code === "500") {
+      msgEl.innerText = "서버 처리 중 오류가 발생했습니다.";
+    } else {
+      msgEl.innerText = "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.";
+    }
+  });
+</script>
+</body>
+</html>

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -73,12 +73,14 @@ class SimpleApiService {
             }
 
             if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
+                sessionStorage.setItem("errorCode", response.status);
+                window.location.href = '/error/error.html';
             }
 
             return await response.json();
         } catch (error) {
             console.error('API GET Error:', error);
+            window.location.href = '/error/error.html';
             throw error;
         }
     }
@@ -99,12 +101,14 @@ class SimpleApiService {
             }
 
             if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
+                sessionStorage.setItem("errorCode", response.status);
+                window.location.href = '/error/error.html';
             }
 
             return await response.json();
         } catch (error) {
             console.error('API POST Error:', error);
+            window.location.href = '/error/error.html';
             throw error;
         }
     }
@@ -125,7 +129,8 @@ class SimpleApiService {
             }
 
             if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
+                sessionStorage.setItem("errorCode", response.status);
+                window.location.href = '/error/error.html';
             }
 
             // 응답이 비어있을 수 있음
@@ -133,6 +138,7 @@ class SimpleApiService {
             return text ? JSON.parse(text) : true;
         } catch (error) {
             console.error('API PUT Error:', error);
+            window.location.href = '/error/error.html';
             throw error;
         }
     }
@@ -150,14 +156,18 @@ class SimpleApiService {
                 this.removeToken();
                 throw new Error('인증이 필요합니다.');
             }
+
             if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
+                sessionStorage.setItem("errorCode", response.status);
+                window.location.href = '/error/error.html';
             }
+
             // 보통 빈 응답이지만, 서버가 JSON을 주면 파싱
             const ct = response.headers.get('content-type') || '';
             return ct.includes('application/json') ? await response.json() : true;
         } catch (err) {
             console.error('API DELETE Error:', err);
+            window.location.href = '/error/error.html';
             throw err;
         }
     }

--- a/src/main/resources/static/js/mission/mission.js
+++ b/src/main/resources/static/js/mission/mission.js
@@ -159,13 +159,10 @@
     try {
       data = await apiService.getMissionSet(missionSetId);
     } catch (e) {
-      mount.innerHTML = `<div class="content-section"><h2 class="content-title">불러오기 실패</h2><p>${e.message || e}</p></div>`;
+      window.location.href = '/error/error.html';
       return;
     }
-    if (!data) {
-      mount.innerHTML = `<div class="content-section"><h2 class="content-title">미션셋 없음</h2><p>해당 missionSetId에 해당하는 미션셋이 없습니다.</p></div>`;
-      return;
-    }
+
 
     const setView = data;
 

--- a/src/main/resources/static/js/mypage/user/user-missions.js
+++ b/src/main/resources/static/js/mypage/user/user-missions.js
@@ -58,10 +58,14 @@ document.addEventListener('DOMContentLoaded', async function () {
 // 팝업 카드 렌더링 유틸 함수
 // =============================
 function renderPopupCard(m, actionText, linkClass) {
-    const popup = m.popup; // ✅ 팝업 객체 분리
+    const popup = m.popup;
 
     const item = document.createElement('div');
     item.className = 'popup-card';
+
+    // 팝업 종료 여부 확인
+    const isEnded = popup.status && popup.status.toUpperCase() === 'ENDED';
+
     item.innerHTML = `
         <div class="popup-image-wrapper">
             ${popup.mainImageUrl && popup.mainImageUrl.trim() !== ""
@@ -73,7 +77,7 @@ function renderPopupCard(m, actionText, linkClass) {
             <div class="popup-summary">${popup.description || '상세설명'}</div>
             <div class="popup-period">${popup.periodText || ''}</div>
             <div class="popup-action">
-                <a class="${linkClass}" href="/missions/${m.missionSetId}">${actionText} &gt;</a>
+                ${!isEnded ? `<a class="${linkClass}" href="/missions/${m.missionSetId}">${actionText} &gt;</a>` : ""}
             </div>
         </div>
     `;


### PR DESCRIPTION
## 📌 Summary
- resolve: #129
- Related Jira: POP-134

## ✨ Description
- 에러페이지 추가
- 끝난 팝업 미션셋 다시보기 버튼 숨김

## 📸 Screenshot
<!-- UI 변화가 없다면 지워주세요 -->
|기능|스크린샷|
|:--:|:--:|
|에러페이지|<img width="1919" height="971" alt="image" src="https://github.com/user-attachments/assets/a72cd6a8-5d39-4a47-b8de-c3b397fba7fc" />|

## 🗒️ Review Point
```
400, 403, 404, 500 코드에 대해서는 각각 상황에 맞는 안내 메시지를 사용자에게 보여주도록 처리했습니다.  
그 외의 오류 코드가 발생하는 경우에는 "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."라는 기본 메시지를 노출하도록 구현했습니다.  
필요한거 더 있으시면 추가해주세요
끝난 팝업 미션셋 다시보기 버튼 숨김 처리한건 에러 페이지 추가하다가 오류 발견했는데 PR 따로 뺼만큼 큰 작업 아니여서 같이 넣었습니다.
```

## ✅ CheckList
- [ ] 에러 페이지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a dedicated error page (Korean) with tailored messages for 404/500 and a quick return to the main page.
  - Unified error handling: API and pages now redirect to the error page on failures for a consistent experience.
- Bug Fixes
  - Prevented interactions with ended popup missions by hiding the action link when a mission has ended.
- Chores
  - Updated access rules to ensure error pages are publicly accessible.
  - Minor whitespace cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->