### PR TITLE
feat #POP-139: 팝업 등록 시 카테고리,태그 반영, 마이페이지 내 정보 및 수정

### DIFF
--- a/src/main/java/com/snow/popin/domain/mypage/host/dto/PopupRegisterRequestDto.java
+++ b/src/main/java/com/snow/popin/domain/mypage/host/dto/PopupRegisterRequestDto.java
@@ -25,6 +25,7 @@ public class PopupRegisterRequestDto {
 
     private List<String> imageUrls;
     private List<PopupHourResponseDto> hours;
-    //태그 정해지면 추가
-    //private List<String> tags;
+
+    private List<Long> tagIds;
+    private Long categoryId;
 }

--- a/src/main/java/com/snow/popin/domain/mypage/provider/repository/ProviderProfileRepository.java
+++ b/src/main/java/com/snow/popin/domain/mypage/provider/repository/ProviderProfileRepository.java
@@ -1,0 +1,12 @@
+package com.snow.popin.domain.mypage.provider.repository;
+
+import com.snow.popin.domain.mypage.provider.entity.ProviderProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface ProviderProfileRepository extends JpaRepository<ProviderProfile, Long> {
+
+    Optional<ProviderProfile> findByUserEmail(String userEmail);
+
+    boolean existsByUserEmail(String userEmail);
+}

--- a/src/main/java/com/snow/popin/domain/popup/entity/Popup.java
+++ b/src/main/java/com/snow/popin/domain/popup/entity/Popup.java
@@ -270,4 +270,8 @@ public class Popup extends BaseEntity {
     public void setStatus(PopupStatus status) {
         this.status = status;
     }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
 }

--- a/src/main/resources/static/css/mypage/host/mpg-host.css
+++ b/src/main/resources/static/css/mypage/host/mpg-host.css
@@ -1,18 +1,35 @@
-/* ===== 공통 ===== */
-.main-content {
+/* mpg-host.css - 마이페이지 호스트 전체 스타일 (provider와 동일한 사용자 정보 디자인) */
+
+/* === 페이지 컨테이너 === */
+.mypage-host {
+    padding: 0;
     background: #f9fafb;
-    padding: 0 20px;
 }
 
+/* === 제목 스타일 (블루 헤더) === */
+.section-title {
+    background: #2563eb !important;
+    border-radius: 12px !important;
+    padding: 20px !important;
+    margin: 20px 16px 24px 16px !important;
+    box-shadow: 0 4px 20px rgba(37, 99, 235, 0.3) !important;
+}
+
+.section-title h2 {
+    color: white !important;
+    font-size: 18px !important;
+    font-weight: 600 !important;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
+    margin: 0 !important;
+}
+
+/* === 공통 블록 스타일 === */
 .block {
-    margin-bottom: 24px;
+    margin: 24px 0;
+    padding: 0 16px;
 }
 
-/* ===== 제목 스타일 (블루 헤더) ===== */
-.block-title,
-.section-title,
-h3.block-title,
-h2.block-title {
+.block-title {
     background: #2563eb !important;
     border-radius: 12px !important;
     padding: 20px !important;
@@ -22,51 +39,35 @@ h2.block-title {
     font-size: 18px !important;
     font-weight: 600 !important;
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
-    margin: 0 0 24px 0 !important;
 }
 
-/* 카드 공통 */
-.card,
-.popup-card,
-.rent-card {
+.card-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+/* === 사용자 정보 === */
+.user-info .card {
     background: white;
     border-radius: 12px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-    border: 1px solid #e5e7eb;
-    padding: 16px;
-    margin-bottom: 12px;
-    transition: transform 0.2s, box-shadow 0.2s;
+    padding: 20px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
-.card:hover,
-.popup-card:hover,
-.rent-card:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-}
-
-.empty {
-    text-align: center;
-    padding: 40px 20px;
-    color: #6b7280;
-    font-size: 14px;
-}
-
-/* ===== 사용자 정보 카드 (흰색 계열) ===== */
-.user-info .card {
-    padding: 0;
+.user-profile {
     background: white;
-    color: #374151;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 0;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .profile-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 16px;
-    border-bottom: 1px solid #f3f4f6;
+    padding: 16px 20px;
+    border-bottom: 1px solid #f0f0f0;
 }
 
 .profile-row:last-child {
@@ -75,7 +76,7 @@ h2.block-title {
 
 .profile-row .label {
     font-weight: 600;
-    color: #111827;
+    color: #374151;
     min-width: 80px;
     font-size: 14px;
 }
@@ -87,325 +88,273 @@ h2.block-title {
     font-size: 14px;
 }
 
-.profile-row .edit-btn {
-    font-size: 12px;
-    padding: 6px 12px;
-    border: 1px solid #e5e7eb;
-    border-radius: 8px;
-    background: #f9fafb;
-    color: #6b7280;
-    cursor: pointer;
-    transition: all 0.2s;
-    font-weight: 500;
+.profile-row.readonly .value {
+    color: #9ca3af;
+    font-style: italic;
 }
 
-.profile-row .edit-btn:hover {
-    background: #f3f4f6;
-    color: #374151;
-    transform: translateY(-1px);
-}
-
-/* ===== 페이지 헤더 ===== */
-.page-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 16px;
-}
-
-.btn-primary.small {
-    padding: 10px 16px;
-    font-size: 14px;
-    background: #1e40af;
+.edit-btn {
+    background: #3b82f6;
     color: white;
     border: none;
-    border-radius: 8px;
-    cursor: pointer;
+    border-radius: 6px;
+    padding: 8px 16px;
+    font-size: 12px;
     font-weight: 500;
+    cursor: pointer;
     transition: all 0.2s;
-    box-shadow: 0 2px 8px rgba(30, 64, 175, 0.3);
 }
 
-.btn-primary.small:hover {
-    background: #1e3a8a;
+.edit-btn:hover {
+    background: #2563eb;
     transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(30, 64, 175, 0.4);
 }
 
-/* ===== 팝업 카드 ===== */
+/* === 인라인 편집 === */
+.inline-edit {
+    flex: 1;
+    margin: 0 12px;
+    padding: 8px 12px;
+    border: 2px solid #3b82f6;
+    border-radius: 8px;
+    font-size: 14px;
+    background: #ffffff;
+    color: #374151;
+    outline: none;
+}
+
+.button-group {
+    display: flex;
+    gap: 8px;
+}
+
+.save-btn, .cancel-btn {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 8px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.save-btn {
+    background: #10b981;
+    color: white;
+}
+
+.save-btn:hover {
+    background: #059669;
+}
+
+.cancel-btn {
+    background: #6b7280;
+    color: white;
+}
+
+.cancel-btn:hover {
+    background: #4b5563;
+}
+
+/* === 팝업 카드 === */
 .popup-card {
+    background: white;
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     display: flex;
     align-items: center;
-    gap: 14px;
+    gap: 16px;
+}
+
+.popup-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 .popup-card .thumb {
-    width: 72px;
-    height: 72px;
-    border-radius: 10px;
-    object-fit: cover;
-    background: #f9fafb;
+    width: 80px;
+    height: 80px;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #f3f4f6;
     flex-shrink: 0;
-    border: 1px solid #e5e7eb;
+}
+
+.popup-card .thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 .popup-card .info {
     flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
 }
 
-.popup-card .info .title {
+.popup-card .title {
     font-size: 16px;
     font-weight: 600;
-    color: #111827;
+    color: #374151;
+    margin-bottom: 8px;
 }
 
-.popup-card .info .meta {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-}
-
-/* 상태 뱃지 */
-.status-badge {
-    display: inline-block;
-    padding: 6px 12px;
-    font-size: 12px;
-    border-radius: 12px;
-    font-weight: 500;
-    white-space: nowrap;
-}
-
-.status-badge.ongoing,
-.status-badge.planned {
-    background: #dbeafe;
-    color: #1e40af;
-}
-
-.status-badge.finished {
-    background: #d1fae5;
-    color: #065f46;
-}
-
-.status-badge.cancelled {
-    background: #fee2e2;
-    color: #991b1b;
-}
-
-.status-badge.pending {
-    background: #fef3c7;
-    color: #92400e;
-}
-
-.status-badge.accepted {
-    background: #d1fae5;
-    color: #065f46;
-}
-
-.status-badge.rejected {
-    background: #fee2e2;
-    color: #991b1b;
-}
-
-/* 팝업 카드 버튼 */
 .popup-card .right-actions {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    flex-shrink: 0;
 }
 
-.popup-card .right-actions button {
-    background: #1e40af;
-    color: white;
-    border: none;
+.btn-detail, .btn-manage, .btn-stats {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
     border-radius: 8px;
-    font-size: 12px;
     padding: 8px 12px;
+    font-size: 12px;
     font-weight: 500;
+    color: #475569;
     cursor: pointer;
     transition: all 0.2s;
-    min-width: 80px;
+    white-space: nowrap;
 }
 
-.popup-card .right-actions button:hover {
-    background: #1e3a8a;
-    transform: translateY(-1px);
-    box-shadow: 0 2px 8px rgba(30, 64, 175, 0.3);
-}
-
-/* ===== 공간 예약 카드 ===== */
+/* === 예약 카드 === */
 .rent-card {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 14px;
+    background: white;
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .rent-card .left {
     display: flex;
-    align-items: center;
-    gap: 12px;
-    flex: 1;
-}
-
-.rent-card .left .thumb {
-    width: 60px;
-    height: 60px;
-    border-radius: 8px;
-    object-fit: cover;
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-}
-
-.rent-card .left .address {
-    font-size: 16px;
-    font-weight: 600;
-    color: #111827;
-    margin-bottom: 4px;
-}
-
-.rent-card .left .desc {
-    font-size: 13px;
-    color: #6b7280;
-    margin-bottom: 4px;
-}
-
-.rent-card .left .dates {
-    font-size: 13px;
-    color: #6b7280;
-    margin-bottom: 8px;
-}
-
-/* 공간 예약 카드 버튼 */
-.rent-card .right-actions {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    flex-shrink: 0;
-}
-
-.rent-card .right-actions button {
-    background: #1e40af;
-    color: white;
-    border: none;
-    border-radius: 8px;
-    font-size: 12px;
-    padding: 8px 12px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-    min-width: 80px;
-}
-
-.rent-card .right-actions button:hover {
-    background: #1e3a8a;
-    transform: translateY(-1px);
-    box-shadow: 0 2px 8px rgba(30, 64, 175, 0.3);
-}
-
-.rent-card .right-actions .btn-cancel {
-    background: #f3f4f6;
-    color: #6b7280;
-    border: 1px solid #e5e7eb;
-}
-
-.rent-card .right-actions .btn-cancel:hover {
-    background: #e5e7eb;
-    color: #374151;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-}
-
-/* ===== 푸터 겹침 방지 ===== */
-.mobile-container {
-    display: flex !important;
-    flex-direction: column !important;
-    min-height: 100vh !important;
-}
-
-.main-content {
-    flex: 1 !important;
-    padding: 0 20px 120px 20px !important;
-    box-sizing: border-box !important;
-}
-
-#footer-container {
-    position: relative !important;
-    flex-shrink: 0 !important;
-}
-
-/* ===== 모바일 대응 ===== */
-@media (max-width: 480px) {
-    .main-content {
-        padding: 0 12px 120px 12px !important;
-    }
-
-    .rent-card .left .thumb {
-        width: 48px;
-        height: 48px;
-    }
-
-    .popup-card .thumb {
-        width: 60px;
-        height: 60px;
-    }
-
-    .popup-card .info .title {
-        font-size: 14px;
-    }
-
-    .popup-card .right-actions,
-    .rent-card .right-actions {
-        flex-direction: row;
-        gap: 6px;
-    }
-
-    .popup-card .right-actions button,
-    .rent-card .right-actions button {
-        flex: 1;
-        min-width: auto;
-        padding: 6px 8px;
-    }
-
-    .profile-row {
-        padding: 12px 16px;
-    }
-
-    .profile-row .label {
-        min-width: 60px;
-        font-size: 13px;
-    }
-
-    .profile-row .value {
-        font-size: 13px;
-    }
-
-    .profile-row .edit-btn {
-        padding: 4px 8px;
-        font-size: 11px;
-    }
-}
-/* ===== 팝업 등록 버튼 (제목 아래 배치) ===== */
-.btn-primary.register-btn {
-    display: block;
-    width: 100%;
-    padding: 12px 20px;
-    font-size: 14px;
-    background: #1e40af;
-    color: white;
-    border: none;
-    border-radius: 8px;
-    cursor: pointer;
-    font-weight: 500;
-    transition: all 0.2s;
-    box-shadow: 0 2px 8px rgba(30, 64, 175, 0.3);
+    gap: 16px;
     margin-bottom: 16px;
 }
 
-.btn-primary.register-btn:hover {
-    background: #1e3a8a;
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(30, 64, 175, 0.4);
+.rent-card .thumb {
+    width: 80px;
+    height: 80px;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #f3f4f6;
+    flex-shrink: 0;
+}
+
+.rent-card .right-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+}
+
+.action-left {
+    display: flex;
+    gap: 8px;
+}
+
+.action-right {
+    display: flex;
+    gap: 8px;
+    margin-left: auto;
+}
+
+/* 공통 버튼 */
+.btn-map, .btn-detail, .btn-cancel, .btn-chat {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    padding: 8px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    color: #475569;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-map:hover, .btn-detail:hover {
+    background: #f1f5f9;
+}
+
+.btn-cancel {
+    background: #fef2f2;
+    border-color: #fecaca;
+    color: #dc2626;
+}
+
+.btn-cancel:hover {
+    background: #fee2e2;
+    border-color: #f87171;
+}
+
+/* 채팅 버튼 - 아이콘 전용 */
+.btn-chat {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #3b82f6;
+    border: none;
+    color: white;
+}
+
+.btn-chat::before {
+    content: "";
+    width: 18px;
+    height: 18px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='white'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4-.8L3 20l1.2-3.6A7.96 7.96 0 013 12c0-4.418 4.03-8 9-8s9 3.582 9 8z'/%3E%3C/svg%3E");
+    background-size: cover;
+}
+
+/* === 등록 버튼 === */
+.register-btn {
+    width: auto;
+    padding: 10px 20px;
+    font-size: 14px;
+    margin-left: auto;
+    display: block;
+    background: #2563eb;
+    color: white;
+    border: none;
+    border-radius: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    margin-bottom: 20px;
+}
+
+.register-btn:hover {
+    background: #1d4ed8;
+    box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3);
+}
+
+/* === 빈 상태 === */
+.empty {
+    text-align: center;
+    padding: 40px 20px;
+    color: #6b7280;
+    font-size: 14px;
+    background: #f9fafb;
+    border-radius: 12px;
+    border: 2px dashed #d1d5db;
+}
+
+/* === 반응형 === */
+@media (max-width: 480px) {
+    .popup-card, .rent-card {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .popup-card .right-actions, .rent-card .right-actions {
+        width: 100%;
+        flex-direction: row;
+        flex-wrap: wrap;
+        margin-top: 12px;
+    }
+
+    .rent-card .left {
+        width: 100%;
+    }
 }

--- a/src/main/resources/static/css/mypage/host/popup-edit.css
+++ b/src/main/resources/static/css/mypage/host/popup-edit.css
@@ -216,3 +216,31 @@ input[type="checkbox"] {
         min-width: auto;
     }
 }
+.tag-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.tag-btn {
+    padding: 8px 14px;
+    border: 1px solid #e5e7eb;
+    border-radius: 20px;
+    background: #f9fafb;
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.2s;
+    color: #374151;
+}
+
+.tag-btn:hover {
+    border-color: #2563eb;
+    color: #2563eb;
+}
+
+.tag-btn.selected {
+    background: #2563eb;
+    color: white;
+    border-color: #2563eb;
+}

--- a/src/main/resources/static/css/mypage/host/popup-register.css
+++ b/src/main/resources/static/css/mypage/host/popup-register.css
@@ -340,3 +340,31 @@
         padding: 12px;
     }
 }
+.tag-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.tag-btn {
+    padding: 8px 14px;
+    border: 1px solid #e5e7eb;
+    border-radius: 20px;
+    background: #f9fafb;
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.2s;
+    color: #374151;
+}
+
+.tag-btn:hover {
+    border-color: #2563eb;
+    color: #2563eb;
+}
+
+.tag-btn.selected {
+    background: #2563eb;
+    color: white;
+    border-color: #2563eb;
+}

--- a/src/main/resources/static/css/mypage/provider/mpg-provider.css
+++ b/src/main/resources/static/css/mypage/provider/mpg-provider.css
@@ -1,4 +1,4 @@
-/* mpg-provider.css - 마이페이지 공간제공자 전체 스타일 */
+/* mpg-provider.css - 마이페이지 공간제공자 전체 스타일 (사용자 정보 기능 포함) */
 
 /* === 페이지 컨테이너 === */
 .mypage-provider {
@@ -47,6 +47,194 @@
     gap: 12px;
 }
 
+/* === 사용자 정보 스타일 === */
+.user-info .card {
+    background: white;
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.profile-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 0;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.profile-row:last-child {
+    border-bottom: none;
+}
+
+.profile-row .label {
+    font-weight: 600;
+    color: #374151;
+    min-width: 80px;
+}
+
+.profile-row .value {
+    flex: 1;
+    margin: 0 12px;
+    color: #6b7280;
+}
+
+.profile-row.readonly .value {
+    color: #9ca3af;
+    font-style: italic;
+}
+
+.edit-btn {
+    background: #3b82f6;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.edit-btn:hover {
+    background: #2563eb;
+}
+
+/* 인라인 편집 스타일 */
+.inline-edit {
+    flex: 1;
+    margin: 0 12px;
+    padding: 6px 8px;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+.button-group {
+    display: flex;
+    gap: 6px;
+}
+
+.save-btn, .cancel-btn {
+    padding: 6px 10px;
+    border: none;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.save-btn {
+    background: #10b981;
+    color: white;
+}
+
+.save-btn:hover {
+    background: #059669;
+}
+
+.cancel-btn {
+    background: #6b7280;
+    color: white;
+}
+
+.cancel-btn:hover {
+    background: #4b5563;
+}
+
+/* === 사용자 정보 스타일 (호스트 페이지에서 가져옴) === */
+.user-info .card {
+    background: white;
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.profile-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 0;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.profile-row:last-child {
+    border-bottom: none;
+}
+
+.profile-row .label {
+    font-weight: 600;
+    color: #374151;
+    min-width: 80px;
+}
+
+.profile-row .value {
+    flex: 1;
+    margin: 0 12px;
+    color: #6b7280;
+}
+
+.profile-row.readonly .value {
+    color: #9ca3af;
+    font-style: italic;
+}
+
+.edit-btn {
+    background: #3b82f6;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.edit-btn:hover {
+    background: #2563eb;
+}
+
+/* 인라인 편집 스타일 */
+.inline-edit {
+    flex: 1;
+    margin: 0 12px;
+    padding: 6px 8px;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+.button-group {
+    display: flex;
+    gap: 6px;
+}
+
+.save-btn, .cancel-btn {
+    padding: 6px 10px;
+    border: none;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.save-btn {
+    background: #10b981;
+    color: white;
+}
+
+.save-btn:hover {
+    background: #059669;
+}
+
+.cancel-btn {
+    background: #6b7280;
+    color: white;
+}
+
+.cancel-btn:hover {
+    background: #4b5563;
+}
+
 /* === 통계 그리드 === */
 .stats-grid {
     display: grid;
@@ -78,64 +266,35 @@
 }
 
 .stat-card .stat-label {
-    font-size: 13px;
+    font-size: 12px;
     color: #6b7280;
-    margin-bottom: 6px;
-    font-weight: 500;
+    margin-bottom: 4px;
 }
 
 .stat-card .stat-number {
-    font-size: 22px;
+    font-size: 18px;
     font-weight: 700;
-    color: #111827;
-}
-
-/* 상태별 색상 */
-.stat-card[data-status="PENDING"] {
-    background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
-    border-color: #fbbf24;
-}
-
-.stat-card[data-status="ACCEPTED"] {
-    background: linear-gradient(135deg, #d1fae5 0%, #a7f3d0 100%);
-    border-color: #34d399;
-}
-
-.stat-card[data-status="REJECTED"] {
-    background: linear-gradient(135deg, #fee2e2 0%, #fecaca 100%);
-    border-color: #f87171;
-}
-
-.stat-card[data-status="ALL"] {
-    background: linear-gradient(135deg, #e0e7ff 0%, #c7d2fe 100%);
-    border-color: #818cf8;
+    color: #374151;
 }
 
 /* === 공간 카드 === */
 .space-card {
+    background: white;
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     display: flex;
     align-items: center;
-    background: #ffffff;
-    border: 1px solid #e5e7eb;
-    border-radius: 16px;
-    padding: 16px;
-    transition: all 0.2s ease;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
-}
-
-.space-card:hover {
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    border-color: #d1d5db;
+    gap: 16px;
 }
 
 .space-card .thumb {
     width: 80px;
     height: 80px;
-    border-radius: 12px;
+    border-radius: 8px;
     overflow: hidden;
-    margin-right: 14px;
-    flex-shrink: 0;
     background: #f3f4f6;
+    flex-shrink: 0;
     cursor: pointer;
 }
 
@@ -147,260 +306,316 @@
 
 .space-card .info {
     flex: 1;
-    min-width: 0;
 }
 
-.space-card .info .title {
+.space-card .title {
     font-size: 16px;
     font-weight: 600;
-    color: #1f2937;
-    margin-bottom: 6px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    color: #374151;
+    margin-bottom: 4px;
     cursor: pointer;
 }
 
-.space-card .info .title.linklike:hover {
-    color: #3b82f6;
+.space-card .title:hover {
+    color: #2563eb;
 }
 
-.space-card .info .desc {
+.space-card .desc {
     font-size: 14px;
     color: #6b7280;
-    line-height: 1.4;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
     cursor: pointer;
 }
 
-/* === 예약 카드 - 타임라인 스타일 === */
+.space-card .desc:hover {
+    color: #374151;
+}
+
+.space-card .btn-row {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.space-card .btn.icon {
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 8px;
+    background: #f3f4f6;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+}
+
+.space-card .btn.icon:hover {
+    background: #e5e7eb;
+    transform: scale(1.05);
+}
+
+/* === 아이콘 스타일 === */
+.icon-map {
+    width: 20px;
+    height: 20px;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23374151'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z'/%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M15 11a3 3 0 11-6 0 3 3 0 016 0z'/%3E%3C/svg%3E") no-repeat center;
+    background-size: contain;
+}
+
+.icon-delete {
+    width: 20px;
+    height: 20px;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23dc2626'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16'/%3E%3C/svg%3E") no-repeat center;
+    background-size: contain;
+}
+
+/* === 예약 카드 === */
 .reservation-card {
     background: white;
-    border-radius: 16px;
-    padding: 0;
-    margin-bottom: 12px;
-    box-shadow: 0 8px 32px rgba(0,0,0,0.1);
+    border-radius: 12px;
     overflow: hidden;
-    position: relative;
-    transition: all 0.2s ease;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    margin-bottom: 16px;
+    border-left: 4px solid #e5e7eb;
 }
 
-.reservation-card:hover {
-    box-shadow: 0 12px 40px rgba(0,0,0,0.15);
-    transform: translateY(-2px);
+.reservation-card.pending {
+    border-left-color: #f59e0b;
 }
 
-.reservation-card::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 6px;
-    background: #f59e0b;
+.reservation-card.accepted {
+    border-left-color: #10b981;
 }
 
-.reservation-card.accepted::before {
-    background: #10b981;
+.reservation-card.rejected {
+    border-left-color: #ef4444;
 }
 
-.reservation-card.rejected::before {
-    background: #ef4444;
+.reservation-card.cancelled {
+    border-left-color: #6b7280;
 }
 
-.reservation-card.cancelled::before {
-    background: #6b7280;
-}
-
-/* 헤더 */
-.reservation-card .timeline-header {
-    background: #f8fafc;
-    padding: 12px 20px;
-    border-bottom: 1px solid #e2e8f0;
+/* 타임라인 헤더 */
+.timeline-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    position: relative;
+    padding: 12px 16px;
+    background: #f9fafb;
+    border-bottom: 1px solid #e5e7eb;
 }
 
-.reservation-card .timeline-status {
+.timeline-status {
     font-size: 12px;
     font-weight: 600;
+    padding: 4px 8px;
+    border-radius: 12px;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
 }
 
-.reservation-card .timeline-status.pending {
-    color: #f59e0b;
+.timeline-status.pending {
+    background: #fef3c7;
+    color: #92400e;
 }
 
-.reservation-card .timeline-status.accepted {
-    color: #10b981;
+.timeline-status.accepted {
+    background: #d1fae5;
+    color: #065f46;
 }
 
-.reservation-card .timeline-status.rejected {
-    color: #ef4444;
+.timeline-status.rejected {
+    background: #fee2e2;
+    color: #991b1b;
 }
 
-.reservation-card .timeline-status.cancelled {
-    color: #6b7280;
+.timeline-status.cancelled {
+    background: #f3f4f6;
+    color: #374151;
 }
 
-/* 삭제 버튼 - 우상단 */
-.reservation-card .btn-delete-top {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    width: 20px;
-    height: 20px;
-    background: rgba(239, 68, 68, 0.8);
+.btn-delete-top {
+    background: none;
     border: none;
-    border-radius: 4px;
-    color: white;
-    font-size: 12px;
+    font-size: 18px;
+    color: #6b7280;
     cursor: pointer;
-    opacity: 0.7;
-    transition: all 0.2s ease;
-    z-index: 2;
+    padding: 4px;
+    border-radius: 4px;
+    transition: all 0.2s;
 }
 
-.reservation-card .btn-delete-top:hover {
-    opacity: 1;
-    background: #dc2626;
+.btn-delete-top:hover {
+    background: #ef4444;
+    color: white;
 }
 
-/* 바디 */
-.reservation-card .timeline-body {
-    padding: 20px;
-    display: flex;
-    gap: 16px;
+/* 타임라인 바디 */
+.timeline-body {
     position: relative;
+    display: flex;
+    padding: 16px;
+    gap: 16px;
 }
 
-.reservation-card .timeline-thumb {
-    width: 64px;
-    height: 64px;
+.timeline-thumb {
+    width: 80px;
+    height: 80px;
     border-radius: 8px;
-    background: linear-gradient(135deg, #e2e8f0, #cbd5e1);
-    flex-shrink: 0;
     overflow: hidden;
+    background: #f3f4f6;
+    flex-shrink: 0;
 }
 
-.reservation-card .timeline-thumb img {
+.timeline-thumb img {
     width: 100%;
     height: 100%;
     object-fit: cover;
 }
 
-.reservation-card .timeline-content {
+.timeline-content {
     flex: 1;
 }
 
-.reservation-card .timeline-title {
-    font-size: 18px;
+.timeline-title {
+    font-size: 16px;
     font-weight: 600;
-    color: #1f2937;
+    color: #374151;
     margin-bottom: 4px;
 }
 
-.reservation-card .timeline-brand {
-    font-size: 14px;
-    font-weight: 500;
-    color: #3b82f6;
-    margin-bottom: 8px;
-    background: #eff6ff;
-    padding: 2px 8px;
-    border-radius: 4px;
-    display: inline-block;
-}
-
-.reservation-card .timeline-dates {
+.timeline-brand {
     font-size: 14px;
     color: #6b7280;
-    margin-bottom: 12px;
+    margin-bottom: 8px;
 }
 
-.reservation-card .timeline-meta {
+.timeline-dates {
+    font-size: 14px;
+    color: #374151;
+    margin-bottom: 8px;
+}
+
+.timeline-meta {
     display: flex;
-    gap: 24px;
-    font-size: 13px;
-    color: #9ca3af;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.timeline-meta span {
+    font-size: 12px;
+    color: #6b7280;
 }
 
 /* 채팅 플로팅 버튼 */
-.reservation-card .chat-floating {
+.chat-floating {
     position: absolute;
-    top: 50%;
-    right: 20px;
-    transform: translateY(-50%);
+    top: 16px;
+    right: 16px;
     width: 40px;
     height: 40px;
-    background: #3b82f6;
     border: none;
     border-radius: 50%;
+    background: #3b82f6;
     color: white;
+    font-size: 16px;
     cursor: pointer;
+    box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
+    transition: all 0.2s;
+}
+
+.chat-floating:hover {
+    background: #2563eb;
+    transform: scale(1.1);
+}
+
+/* 액션바 */
+.action-bar {
+    display: flex;
+    border-top: 1px solid #e5e7eb;
+}
+
+.action-btn {
+    flex: 1;
+    border: none;
+    padding: 12px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 16px;
-    box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
-    transition: all 0.2s ease;
-    z-index: 1;
-}
-
-.reservation-card .chat-floating:hover {
-    background: #2563eb;
-    transform: translateY(-50%) scale(1.05);
-    box-shadow: 0 6px 20px rgba(59, 130, 246, 0.4);
-}
-
-/* 하단 액션바 */
-.reservation-card .action-bar {
-    background: #f8fafc;
-    border-top: 1px solid #e2e8f0;
-    padding: 12px 20px;
-    display: flex;
-    justify-content: flex-end;
-    gap: 8px;
-}
-
-/* 수락/거절 버튼 */
-.reservation-card .action-btn {
-    display: flex;
-    align-items: center;
     gap: 6px;
-    padding: 8px 12px;
-    border: none;
+}
+
+.btn-accept {
+    background: #f0f9ff;
+    color: #0369a1;
+    border-right: 1px solid #e5e7eb;
+}
+
+.btn-accept:hover {
+    background: #dbeafe;
+}
+
+.btn-reject {
+    background: #fef2f2;
+    color: #dc2626;
+}
+
+.btn-reject:hover {
+    background: #fee2e2;
+}
+
+/* === 빈 상태 === */
+.empty {
+    text-align: center;
+    padding: 40px 20px;
+    color: #6b7280;
+    font-size: 14px;
+}
+
+/* === 오류 상태 === */
+.error {
+    text-align: center;
+    padding: 40px 20px;
+    color: #dc2626;
+    font-size: 14px;
+    background: #fef2f2;
     border-radius: 8px;
-    font-size: 12px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s ease;
+    margin: 20px;
 }
 
-.reservation-card .btn-accept {
-    background: #10b981;
-    color: white;
+/* === 아이콘 스타일 (SVG 우선) === */
+.icon-map,
+.icon-delete,
+.icon-detail {
+    width: 20px !important;
+    height: 20px !important;
+    background-size: 16px 16px !important;
+    background-position: center !important;
+    background-repeat: no-repeat !important;
+    display: block !important;
 }
 
-.reservation-card .btn-accept:hover {
-    background: #059669;
-    transform: translateY(-1px);
+/* SVG 배경 이미지가 우선 적용되도록 */
+.icon-map {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='rgb(107,114,128)'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z'/%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M15 11a3 3 0 11-6 0 3 3 0 016 0z'/%3E%3C/svg%3E") !important;
 }
 
-.reservation-card .btn-reject {
-    background: #ef4444;
-    color: white;
+.icon-delete {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='rgb(220,38,38)'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16'/%3E%3C/svg%3E") !important;
 }
 
-.reservation-card .btn-reject:hover {
-    background: #dc2626;
-    transform: translateY(-1px);
+.icon-detail {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='rgb(37,99,235)'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'/%3E%3C/svg%3E") !important;
+}
+
+/* 이모지 fallback 제거 (SVG가 우선되도록) */
+.icon-map::before,
+.icon-delete::before,
+.icon-detail::before {
+    display: none !important;
 }
 
 /* === 기존 버튼 스타일 (공간 카드용) === */
@@ -445,110 +660,4 @@
     height: 36px;
     padding: 0;
     border-radius: 10px;
-}
-
-/* === 아이콘 스타일 === */
-.icon-map,
-.icon-delete,
-.icon-detail {
-    width: 20px;
-    height: 20px;
-    background-size: 16px 16px;
-    background-position: center;
-    background-repeat: no-repeat;
-}
-
-.icon-map {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%236b7280'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z'/%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M15 11a3 3 0 11-6 0 3 3 0 016 0z'/%3E%3C/svg%3E");
-}
-
-.icon-delete {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%236b7280'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16'/%3E%3C/svg%3E");
-}
-
-.icon-detail {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%236b7280'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'/%3E%3C/svg%3E");
-}
-
-/* === 빈 상태 === */
-.empty {
-    text-align: center;
-    padding: 48px 20px;
-    color: #9ca3af;
-    font-size: 14px;
-    background: #f9fafb;
-    border-radius: 16px;
-    border: 2px dashed #e5e7eb;
-}
-
-/* === 에러 상태 === */
-.error {
-    text-align: center;
-    padding: 40px 20px;
-    color: #ef4444;
-    font-size: 14px;
-    background: #fef2f2;
-    border-radius: 16px;
-    border: 1px solid #fecaca;
-    margin: 20px 16px;
-}
-
-/* === 모바일 반응형 === */
-@media (max-width: 480px) {
-    .stats-grid {
-        grid-template-columns: repeat(2, 1fr);
-        gap: 8px;
-    }
-
-    .reservation-card .timeline-body {
-        flex-direction: column;
-        padding-right: 60px; /* 채팅 버튼 공간 확보 */
-    }
-
-    .reservation-card .timeline-thumb {
-        width: 100%;
-        height: 120px;
-        margin-bottom: 12px;
-    }
-
-    .reservation-card .timeline-meta {
-        flex-direction: column;
-        gap: 8px;
-    }
-
-    .reservation-card .chat-floating {
-        top: 60px;
-        right: 15px;
-        width: 36px;
-        height: 36px;
-        font-size: 14px;
-    }
-
-    .reservation-card .action-bar {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 6px;
-    }
-}
-
-@media (max-width: 360px) {
-    .section-title h2 {
-        font-size: 20px;
-    }
-
-    .space-card {
-        flex-direction: column;
-    }
-
-    .space-card .thumb {
-        width: 100%;
-        height: 140px;
-        margin-right: 0;
-        margin-bottom: 12px;
-    }
-
-    .space-card .btn-row {
-        width: 100%;
-        margin-top: 12px;
-    }
 }

--- a/src/main/resources/static/js/mypage/host/popup-register.js
+++ b/src/main/resources/static/js/mypage/host/popup-register.js
@@ -10,7 +10,28 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     setupImagePreview();
+    setupTagSelection();
 });
+
+function setupTagSelection() {
+    const selectedTags = new Set();
+    const tagButtons = document.querySelectorAll(".tag-btn");
+
+    tagButtons.forEach(btn => {
+        btn.addEventListener("click", () => {
+            const tagId = parseInt(btn.dataset.id, 10);
+            if (selectedTags.has(tagId)) {
+                selectedTags.delete(tagId);
+                btn.classList.remove("selected");
+            } else {
+                selectedTags.add(tagId);
+                btn.classList.add("selected");
+            }
+        });
+    });
+
+    window.getSelectedTags = () => Array.from(selectedTags);
+}
 
 function addHourItem() {
     const container = document.getElementById("hours-container");
@@ -200,7 +221,9 @@ async function collectFormData() {
         mainImageUrl: mainImageUrl,
         isFeatured: false,
         imageUrls: imageUrls,
-        hours: hours
+        hours: hours,
+        categoryId: parseInt(document.getElementById("categoryId")?.value) || null,
+        tagIds: window.getSelectedTags ? window.getSelectedTags() : []
     };
 
     return formData;

--- a/src/main/resources/static/templates/pages/mypage/host/mpg-host.html
+++ b/src/main/resources/static/templates/pages/mypage/host/mpg-host.html
@@ -21,19 +21,37 @@
     <!-- 메인 콘텐츠 영역 -->
     <main class="main-content" id="main-content">
 
-        <!-- 마이페이지 (변경) -->
+        <!-- 마이페이지 -->
         <section class="block user-info">
-            <h3 class="block-title">마이페이지</h3>
+            <h3 class="block-title">마이페이지 - 팝업 주최자</h3>
             <div class="card user-profile">
-                <div class="profile-row"><span class="label">계정명</span><span id="user-email" class="value"></span><button class="edit-btn">수정</button></div>
-                <div class="profile-row"><span class="label">이름</span><span id="user-name" class="value"></span><button class="edit-btn">수정</button></div>
-                <div class="profile-row"><span class="label">닉네임</span><span id="user-nickname" class="value"></span><button class="edit-btn">수정</button></div>
-                <div class="profile-row"><span class="label">연락처</span><span id="user-phone" class="value"></span><button class="edit-btn">수정</button></div>
-                <div class="profile-row"><span class="label">브랜드명</span><span id="user-brand" class="value"></span><button class="edit-btn">수정</button></div>
+                <div class="profile-row readonly">
+                    <span class="label">계정명</span>
+                    <span id="user-email" class="value"></span>
+                </div>
+                <div class="profile-row">
+                    <span class="label">이름</span>
+                    <span id="user-name" class="value"></span>
+                    <button class="edit-btn">수정</button>
+                </div>
+                <div class="profile-row">
+                    <span class="label">닉네임</span>
+                    <span id="user-nickname" class="value"></span>
+                    <button class="edit-btn">수정</button>
+                </div>
+                <div class="profile-row">
+                    <span class="label">연락처</span>
+                    <span id="user-phone" class="value"></span>
+                    <button class="edit-btn">수정</button>
+                </div>
+                <div class="profile-row readonly">
+                    <span class="label">브랜드명</span>
+                    <span id="user-brand" class="value"></span>
+                </div>
             </div>
         </section>
 
-        <!-- 내가 등록한 팝업 (레이아웃 변경) -->
+        <!-- 내가 등록한 팝업 -->
         <section class="block">
             <h3 class="block-title">내가 등록한 팝업</h3>
             <button id="btn-popup-register" class="btn-primary register-btn">팝업 등록하기</button>
@@ -72,7 +90,6 @@
     document.addEventListener('DOMContentLoaded', async function() {
         await loadComponents();
         initializeLayout();
-        // 이 페이지는 HostPage 전용
         if (window.HostPage) {
             HostPage.init();
         }

--- a/src/main/resources/static/templates/pages/mypage/host/popup-edit.html
+++ b/src/main/resources/static/templates/pages/mypage/host/popup-edit.html
@@ -1,111 +1,119 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title id="page-title">팝업 수정 | POPIN</title>
-
-    <!-- 공통 레이아웃 CSS -->
-    <link rel="stylesheet" href="/css/layout.css">
-
-    <!-- 페이지별 CSS (등록 폼 CSS 재사용) -->
-    <link rel="stylesheet" href="/css/mypage/host/popup-edit.css">
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>팝업 수정 | POPIN</title>
+    <link rel="stylesheet" href="/css/layout.css"/>
+    <link rel="stylesheet" href="/css/mypage/host/popup-edit.css"/>
 </head>
 <body>
 <div class="mobile-container">
-    <!-- 헤더 영역 -->
-    <div id="header-container">
-        <!-- JavaScript로 동적 로드 -->
-    </div>
+    <div id="header-container"></div>
 
-    <!-- 메인 콘텐츠 영역 -->
     <main class="main-content" id="main-content">
+        <div class="container">
+            <h2 class="section-title">팝업 수정</h2>
 
-        <!-- 팝업 수정 폼 -->
-        <section class="block">
-            <div class="page-header">
-                <h3 class="block-title">팝업 수정</h3>
-            </div>
-
-            <form id="popup-edit-form" class="popup-form">
+            <form id="popup-edit-form">
                 <div class="form-group">
                     <label for="title">제목</label>
-                    <input type="text" id="title" name="title" required />
+                    <input type="text" id="title" name="title" required/>
                 </div>
+
                 <div class="form-group">
                     <label for="summary">요약</label>
-                    <input type="text" id="summary" name="summary" />
+                    <input type="text" id="summary" name="summary"/>
                 </div>
+
                 <div class="form-group">
                     <label for="description">설명</label>
                     <textarea id="description" name="description"></textarea>
                 </div>
+
                 <div class="form-group">
                     <label for="startDate">시작일</label>
-                    <input type="date" id="startDate" name="startDate" required />
+                    <input type="date" id="startDate" name="startDate" required/>
                 </div>
+
                 <div class="form-group">
                     <label for="endDate">종료일</label>
-                    <input type="date" id="endDate" name="endDate" required />
+                    <input type="date" id="endDate" name="endDate" required/>
                 </div>
+
                 <div class="form-group">
                     <label for="entryFee">입장료</label>
-                    <input type="number" id="entryFee" name="entryFee" />
+                    <input type="number" id="entryFee" name="entryFee" value="0"/>
                 </div>
-                <div class="form-group checkbox">
-                    <label><input type="checkbox" id="reservationAvailable" /> 예약 가능 여부</label>
+
+                <!-- 카테고리 -->
+                <div class="form-group">
+                    <label for="categoryId">카테고리</label>
+                    <select id="categoryId" name="categoryId" required>
+                        <option value="">카테고리를 선택하세요</option>
+                        <option value="1">패션</option>
+                        <option value="2">반려동물</option>
+                        <option value="3">게임</option>
+                        <option value="4">캐릭터/IP</option>
+                        <option value="5">문화/컨텐츠</option>
+                        <option value="6">연예</option>
+                        <option value="7">여행/레저/스포츠</option>
+                    </select>
                 </div>
+
+                <!-- 태그 -->
+                <div class="form-group">
+                    <label>태그 선택</label>
+                    <div id="tag-container" class="tag-container">
+                        <button type="button" class="tag-btn" data-id="1">할인</button>
+                        <button type="button" class="tag-btn" data-id="2">한정판</button>
+                        <button type="button" class="tag-btn" data-id="3">체험존</button>
+                        <button type="button" class="tag-btn" data-id="4">콜라보</button>
+                        <button type="button" class="tag-btn" data-id="5">신제품</button>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label><input type="checkbox" id="reservationAvailable"/> 예약 가능 여부</label>
+                </div>
+
                 <div class="form-group">
                     <label for="reservationLink">예약 링크</label>
-                    <input type="text" id="reservationLink" name="reservationLink" />
+                    <input type="text" id="reservationLink" name="reservationLink"/>
                 </div>
-                <div class="form-group checkbox">
-                    <label><input type="checkbox" id="waitlistAvailable" /> 대기자 등록 가능 여부</label>
+
+                <div class="form-group">
+                    <label><input type="checkbox" id="waitlistAvailable"/> 대기자 등록 가능 여부</label>
                 </div>
+
                 <div class="form-group">
                     <label for="notice">공지사항</label>
                     <textarea id="notice" name="notice"></textarea>
                 </div>
+
                 <div class="form-group">
                     <label for="mainImageUrl">대표 이미지 URL</label>
-                    <input type="text" id="mainImageUrl" name="mainImageUrl" />
+                    <input type="text" id="mainImageUrl" name="mainImageUrl"/>
                 </div>
-                <div class="form-group checkbox">
-                    <label><input type="checkbox" id="isFeatured" /> 추천 여부</label>
+
+                <div class="form-group">
+                    <label><input type="checkbox" id="isFeatured"/> 메인 노출 여부</label>
                 </div>
 
                 <div class="form-actions">
-                    <button type="submit" class="btn-primary">수정 완료</button>
+                    <button type="submit" class="btn-primary">수정하기</button>
                     <button type="button" class="btn-secondary" onclick="history.back()">취소</button>
                 </div>
             </form>
-        </section>
-
+        </div>
     </main>
 
-    <!-- 푸터 영역 -->
-    <div id="footer-container">
-        <!-- JavaScript로 동적 로드 -->
-    </div>
+    <div id="footer-container"></div>
 </div>
 
-<!-- 공통 스크립트 -->
 <script src="/js/templateLoader.js"></script>
 <script src="/js/api.js"></script>
 <script src="/js/layout.js"></script>
-
-<!-- 페이지별 스크립트 -->
 <script src="/js/mypage/host/popup-edit.js"></script>
-
-<!-- 초기화 -->
-<script>
-    document.addEventListener('DOMContentLoaded', async function() {
-        await loadComponents();
-        initializeLayout();
-        if (window.PopupEditPage) {
-            PopupEditPage.init();
-        }
-    });
-</script>
 </body>
 </html>

--- a/src/main/resources/static/templates/pages/mypage/host/popup-register.html
+++ b/src/main/resources/static/templates/pages/mypage/host/popup-register.html
@@ -51,6 +51,33 @@
                     <input type="number" id="entryFee" name="entryFee" value="0" />
                 </div>
 
+                <!-- 카테고리 선택 -->
+                <div class="form-group">
+                    <label for="categoryId">카테고리</label>
+                    <select id="categoryId" name="categoryId" required>
+                        <option value="">카테고리를 선택하세요</option>
+                        <option value="1">패션</option>
+                        <option value="2">반려동물</option>
+                        <option value="3">게임</option>
+                        <option value="4">캐릭터/IP</option>
+                        <option value="5">문화/컨텐츠</option>
+                        <option value="6">연예</option>
+                        <option value="7">여행/레저/스포츠</option>
+                    </select>
+                </div>
+
+                <!-- 태그 선택 -->
+                <div class="form-group">
+                    <label>태그 선택</label>
+                    <div id="tag-container" class="tag-container">
+                        <button type="button" class="tag-btn" data-id="1">할인</button>
+                        <button type="button" class="tag-btn" data-id="2">한정판</button>
+                        <button type="button" class="tag-btn" data-id="3">체험존</button>
+                        <button type="button" class="tag-btn" data-id="4">콜라보</button>
+                        <button type="button" class="tag-btn" data-id="5">신제품</button>
+                    </div>
+                </div>
+
                 <div class="form-group">
                     <label><input type="checkbox" id="reservationAvailable" /> 예약 가능 여부</label>
                 </div>
@@ -83,6 +110,7 @@
                     <input type="file" id="extraImageFiles" accept="image/*" multiple />
                     <div id="extraImagePreview" class="image-preview"></div>
                 </div>
+
                 <!-- 운영 시간 -->
                 <div class="form-group">
                     <label>운영 시간</label>
@@ -109,18 +137,5 @@
 
 <!-- 페이지 전용 스크립트 -->
 <script src="/js/mypage/host/popup-register.js"></script>
-
-<script>
-    document.addEventListener('DOMContentLoaded', async () => {
-        try {
-            await loadComponents();
-            initializeLayout();
-        } catch (error) {
-            console.error('페이지 초기화 오류:', error);
-            document.getElementById('main-content').innerHTML =
-                '<div class="error">페이지 로딩 중 오류가 발생했습니다: ' + error.message + '</div>';
-        }
-    });
-</script>
 </body>
 </html>

--- a/src/main/resources/static/templates/pages/mypage/provider/mpg-provider.html
+++ b/src/main/resources/static/templates/pages/mypage/provider/mpg-provider.html
@@ -24,6 +24,32 @@
       </div>
       <br>
 
+      <!-- 사용자 정보 섹션 추가 -->
+      <section class="block user-info">
+        <div class="card user-profile">
+          <div class="profile-row readonly">
+            <span class="label">계정명</span>
+            <span id="user-email" class="value">-</span>
+          </div>
+          <div class="profile-row">
+            <span class="label">이름</span>
+            <span id="user-name" class="value">-</span>
+            <button class="edit-btn">수정</button>
+          </div>
+          <div class="profile-row">
+            <span class="label">닉네임</span>
+            <span id="user-nickname" class="value">-</span>
+            <button class="edit-btn">수정</button>
+          </div>
+          <div class="profile-row">
+            <span class="label">연락처</span>
+            <span id="user-phone" class="value">-</span>
+            <button class="edit-btn">수정</button>
+          </div>
+
+        </div>
+      </section>
+
       <!-- 등록 장소 -->
       <section class="block">
         <h3 class="block-title">등록 장소</h3>


### PR DESCRIPTION
## 📌 Summary
- resolve: #137 
- Related Jira: POP-139
## ✨ Description
- 팝업 생성 시, 카테고리와 태그 입력 기능
- 마이페이지의 내 정보 누락 적용 및 수정 적용
- 계정의 ROLE 승격 시, 해당 테이블(BRAND, BRAND_MEMBERS) 에 반영

## 📸 Screenshot
<img width="601" height="225" alt="image" src="https://github.com/user-attachments/assets/544097df-b9e8-4596-9f16-6a1020702012" />
<img width="586" height="293" alt="image" src="https://github.com/user-attachments/assets/428ee361-b937-42af-9a40-ab93f2c7b9a3" />


## 🗒️ Review Point
```

```

## ✅ CheckList
- [ ] check 1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic setup of host/provider data upon role upgrade approval.
  - Notifications sent for space reservations (create, approve, reject, cancel).
  - Popups now support category and tags on create/edit, with tag selection UI.
  - Inline editing of name, nickname, and phone on Host/Provider My Page.

- Style
  - Major visual refresh of Host/Provider My Page: modern cards, buttons, states, and responsive layouts.
  - Redesigned reservation and popup cards with standardized action buttons and chat control.
  - Updated popup edit/register pages with structured forms, category dropdowns, and tag selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->