### PR TITLE
feat #POP-148: 검색어 자동완성 기능 구현

### DIFF
--- a/src/main/java/com/snow/popin/domain/popup/controller/PopupSearchController.java
+++ b/src/main/java/com/snow/popin/domain/popup/controller/PopupSearchController.java
@@ -1,16 +1,20 @@
 package com.snow.popin.domain.popup.controller;
 
 import com.snow.popin.domain.popup.dto.request.PopupSearchRequestDto;
+import com.snow.popin.domain.popup.dto.response.AutocompleteResponseDto;
 import com.snow.popin.domain.popup.dto.response.PopupListResponseDto;
 import com.snow.popin.domain.popup.service.PopupSearchService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/search")
 @RequiredArgsConstructor
@@ -18,10 +22,40 @@ public class PopupSearchController {
 
     private final PopupSearchService popupSearchService;
 
-    //  팝업스토어 검색 (제목, 태그)
+    // 팝업스토어 검색 (제목, 태그)
     @GetMapping("/popups")
     public ResponseEntity<PopupListResponseDto> searchPopups(@Valid PopupSearchRequestDto request) {
+        log.info("팝업 검색 요청 - query: {}, page: {}, size: {}",
+                request.getQuery(), request.getPage(), request.getSize());
+
         PopupListResponseDto response = popupSearchService.searchPopups(request);
         return ResponseEntity.ok(response);
+    }
+
+    // 자동완성 리스트 조회
+    // 팝업 제목과 태그에서 검색어와 일치하는 항목들을 반환
+    @GetMapping("/suggestions")
+    public ResponseEntity<AutocompleteResponseDto> getAutocompleteSuggestions(
+            @RequestParam(value = "q", required = false) String query) {
+
+        log.info("자동완성 제안 요청 - query: {}", query);
+
+        // 검색어가 없거나 너무 짧으면 빈 결과 반환
+        if (query == null || query.trim().length() < 1) {
+            log.info("자동완성 검색어 부족 - query: {}", query);
+            return ResponseEntity.ok(AutocompleteResponseDto.empty(query));
+        }
+
+        try {
+            // 간단한 검색만 사용 (안정적이고 모든 상태 포함)
+            AutocompleteResponseDto response = popupSearchService.getSimpleAutocompleteSuggestions(query);
+
+            log.info("자동완성 제안 완료 - query: {}, 결과 수: {}", query, response.getTotalCount());
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("자동완성 제안 요청 실패 - query: {}", query, e);
+            return ResponseEntity.ok(AutocompleteResponseDto.empty(query));
+        }
     }
 }

--- a/src/main/java/com/snow/popin/domain/popup/dto/request/PopupSearchRequestDto.java
+++ b/src/main/java/com/snow/popin/domain/popup/dto/request/PopupSearchRequestDto.java
@@ -9,7 +9,6 @@ import javax.validation.constraints.Size;
 @Getter
 public class PopupSearchRequestDto {
 
-    @Size(min = 2, max = 100, message = "검색어는 2~100자여야 합니다.")
     private String query;
 
     @Min(0)

--- a/src/main/java/com/snow/popin/domain/popup/dto/request/PopupSearchRequestDto.java
+++ b/src/main/java/com/snow/popin/domain/popup/dto/request/PopupSearchRequestDto.java
@@ -1,5 +1,6 @@
 package com.snow.popin.domain.popup.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import javax.validation.constraints.Max;
@@ -18,23 +19,19 @@ public class PopupSearchRequestDto {
     @Max(100)
     private int size = 20;
 
-    public void setQuery(String query) {
+    @Builder
+    private PopupSearchRequestDto(String query, int page, int size) {
         this.query = query;
+        this.page = Math.max(0, page);
+        this.size = Math.min(Math.max(1, size), 100);
     }
 
-    public void setPage(int page) {
-        this.page = page;
-    }
-
-    public void setSize(int size) {
-        this.size = size;
-    }
-
-    public boolean hasQuery() {
-        return query != null && !query.trim().isEmpty();
-    }
-
-    public boolean isValidQueryLength() {
-        return hasQuery() && query.trim().length() >= 2;
+    // 팩토리 메서드
+    public static PopupSearchRequestDto of(String query, int page, int size) {
+        return PopupSearchRequestDto.builder()
+                .query(query)
+                .page(page)
+                .size(size)
+                .build();
     }
 }

--- a/src/main/java/com/snow/popin/domain/popup/dto/response/AutocompleteResponseDto.java
+++ b/src/main/java/com/snow/popin/domain/popup/dto/response/AutocompleteResponseDto.java
@@ -1,0 +1,29 @@
+package com.snow.popin.domain.popup.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+* 자동완성 응답 전체 DTO
+ */
+@Getter
+public class AutocompleteResponseDto {
+    private final List<AutocompleteSuggestionDto> suggestions;
+    private final String query;
+    private final int totalCount;
+
+    private AutocompleteResponseDto(List<AutocompleteSuggestionDto> suggestions, String query) {
+        this.suggestions = suggestions;
+        this.query = query;
+        this.totalCount = suggestions.size();
+    }
+
+    public static AutocompleteResponseDto of(List<AutocompleteSuggestionDto> suggestions, String query) {
+        return new AutocompleteResponseDto(suggestions, query);
+    }
+
+    public static AutocompleteResponseDto empty(String query) {
+        return new AutocompleteResponseDto(List.of(), query);
+    }
+}

--- a/src/main/java/com/snow/popin/domain/popup/dto/response/AutocompleteSuggestionDto.java
+++ b/src/main/java/com/snow/popin/domain/popup/dto/response/AutocompleteSuggestionDto.java
@@ -1,0 +1,31 @@
+package com.snow.popin.domain.popup.dto.response;
+
+import lombok.Getter;
+
+/**
+ * 자동완성 제안 응답 DTO
+ */
+@Getter
+public class AutocompleteSuggestionDto {
+    private final String text;        // 표시될 텍스트 (예: "브런치 팝업")
+    private final String type;        // 타입 ("title" 또는 "tag")
+    private final Long popularity;    // 인기도 (조회수 또는 사용 횟수)
+
+    private AutocompleteSuggestionDto(String text, String type, Long popularity) {
+        this.text = text;
+        this.type = type;
+        this.popularity = popularity;
+    }
+
+    public static AutocompleteSuggestionDto of(String text, String type, Long popularity) {
+        return new AutocompleteSuggestionDto(text, type, popularity);
+    }
+
+    public static AutocompleteSuggestionDto fromTitle(String title, Long viewCount) {
+        return new AutocompleteSuggestionDto(title, "title", viewCount);
+    }
+
+    public static AutocompleteSuggestionDto fromTag(String tagName, Long usageCount) {
+        return new AutocompleteSuggestionDto(tagName, "tag", usageCount);
+    }
+}

--- a/src/main/java/com/snow/popin/domain/popup/repository/PopupSearchRepository.java
+++ b/src/main/java/com/snow/popin/domain/popup/repository/PopupSearchRepository.java
@@ -13,49 +13,28 @@ import java.util.List;
 @Repository
 public interface PopupSearchRepository extends JpaRepository<Popup, Long> {
 
-    // 제목과 태그로 검색
-    @Query(value = "SELECT DISTINCT p FROM Popup p " +
-            "LEFT JOIN p.venue v " +
+    /**
+     * 팝업 제목과 태그로 검색 (2글자 이상)
+     */
+    @Query("SELECT DISTINCT p FROM Popup p " +
             "LEFT JOIN p.tags t " +
-            "WHERE (:query IS NULL OR TRIM(:query) = '' OR " +
-            "     LOWER(p.title) LIKE LOWER(CONCAT('%', :query, '%')) OR " +
-            "     LOWER(p.summary) LIKE LOWER(CONCAT('%', :query, '%')) OR " +
-            "     LOWER(t.name) LIKE LOWER(CONCAT('%', :query, '%'))) " +
-            "ORDER BY p.createdAt DESC",
-            countQuery = "SELECT count(DISTINCT p) FROM Popup p " +
-                    "LEFT JOIN p.tags t " +
-                    "WHERE (:query IS NULL OR TRIM(:query) = '' OR " +
-                    "     LOWER(p.title) LIKE LOWER(CONCAT('%', :query, '%')) OR " +
-                    "     LOWER(p.summary) LIKE LOWER(CONCAT('%', :query, '%')) OR " +
-                    "     LOWER(t.name) LIKE LOWER(CONCAT('%', :query, '%')))")
+            "WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            "   OR LOWER(t.name) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            "ORDER BY p.createdAt DESC")
     Page<Popup> searchByTitleAndTags(@Param("query") String query, Pageable pageable);
 
-    // 자동완성용: 팝업 제목에서 검색어가 포함된 제목들을 찾기
-    @Query("SELECT DISTINCT p.title FROM Popup p " +
-            "WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :query, '%')) " +
-            "ORDER BY LENGTH(p.title), p.title")
-    List<String> findPopupTitleSuggestions(@Param("query") String query, Pageable pageable);
-
-    // 자동완성용: 태그에서 검색어가 포함된 태그들을 찾기
-    @Query("SELECT DISTINCT t.name FROM Popup p " +
-            "LEFT JOIN p.tags t " +
-            "WHERE LOWER(t.name) LIKE LOWER(CONCAT('%', :query, '%')) " +
-            "ORDER BY LENGTH(t.name), t.name")
-    List<String> findTagSuggestions(@Param("query") String query, Pageable pageable);
-
-    // 자동완성용: 통합 검색어 제안 (제목 + 태그, 모든 상태)
+    /**
+     * 자동완성 - 제목과 태그에서 검색어 포함된 것들 통합 조회
+     */
     @Query(value = "(" +
-            "SELECT p.title as suggestion, 'title' as type, p.view_count as popularity " +
-            "FROM popups p " +
+            "SELECT DISTINCT p.title as suggestion FROM popups p " +
             "WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :query, '%')) " +
-            ") UNION ALL (" +
-            "SELECT t.name as suggestion, 'tag' as type, COUNT(pt.popup_id) as popularity " +
-            "FROM tags t " +
-            "LEFT JOIN popup_tags pt ON t.id = pt.tag_id " +
-            "LEFT JOIN popups p ON pt.popup_id = p.id " +
-            "WHERE LOWER(t.name) LIKE LOWER(CONCAT('%', :query, '%')) " +
-            "GROUP BY t.name " +
-            ") ORDER BY popularity DESC, LENGTH(suggestion), suggestion " +
+            "UNION " +
+            "SELECT DISTINCT t.name as suggestion FROM popups p " +
+            "JOIN popup_tags pt ON p.id = pt.popup_id " +
+            "JOIN tags t ON pt.tag_id = t.id " +
+            "WHERE LOWER(t.name) LIKE LOWER(CONCAT('%', :query, '%'))" +
+            ") ORDER BY LENGTH(suggestion), suggestion " +
             "LIMIT :limit", nativeQuery = true)
-    List<Object[]> findSuggestions(@Param("query") String query, @Param("limit") int limit);
+    List<String> findSuggestions(@Param("query") String query, @Param("limit") int limit);
 }

--- a/src/main/java/com/snow/popin/domain/popup/repository/PopupSearchRepository.java
+++ b/src/main/java/com/snow/popin/domain/popup/repository/PopupSearchRepository.java
@@ -8,12 +8,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PopupSearchRepository extends JpaRepository<Popup, Long> {
 
     // 제목과 태그로 검색
     @Query(value = "SELECT DISTINCT p FROM Popup p " +
-            "LEFT JOIN FETCH p.venue v " +
+            "LEFT JOIN p.venue v " +
             "LEFT JOIN p.tags t " +
             "WHERE (:query IS NULL OR TRIM(:query) = '' OR " +
             "     LOWER(p.title) LIKE LOWER(CONCAT('%', :query, '%')) OR " +
@@ -28,5 +30,32 @@ public interface PopupSearchRepository extends JpaRepository<Popup, Long> {
                     "     LOWER(t.name) LIKE LOWER(CONCAT('%', :query, '%')))")
     Page<Popup> searchByTitleAndTags(@Param("query") String query, Pageable pageable);
 
-    //TODO: 추천 검색어
+    // 자동완성용: 팝업 제목에서 검색어가 포함된 제목들을 찾기
+    @Query("SELECT DISTINCT p.title FROM Popup p " +
+            "WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            "ORDER BY LENGTH(p.title), p.title")
+    List<String> findPopupTitleSuggestions(@Param("query") String query, Pageable pageable);
+
+    // 자동완성용: 태그에서 검색어가 포함된 태그들을 찾기
+    @Query("SELECT DISTINCT t.name FROM Popup p " +
+            "LEFT JOIN p.tags t " +
+            "WHERE LOWER(t.name) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            "ORDER BY LENGTH(t.name), t.name")
+    List<String> findTagSuggestions(@Param("query") String query, Pageable pageable);
+
+    // 자동완성용: 통합 검색어 제안 (제목 + 태그, 모든 상태)
+    @Query(value = "(" +
+            "SELECT p.title as suggestion, 'title' as type, p.view_count as popularity " +
+            "FROM popups p " +
+            "WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            ") UNION ALL (" +
+            "SELECT t.name as suggestion, 'tag' as type, COUNT(pt.popup_id) as popularity " +
+            "FROM tags t " +
+            "LEFT JOIN popup_tags pt ON t.id = pt.tag_id " +
+            "LEFT JOIN popups p ON pt.popup_id = p.id " +
+            "WHERE LOWER(t.name) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            "GROUP BY t.name " +
+            ") ORDER BY popularity DESC, LENGTH(suggestion), suggestion " +
+            "LIMIT :limit", nativeQuery = true)
+    List<Object[]> findSuggestions(@Param("query") String query, @Param("limit") int limit);
 }

--- a/src/main/java/com/snow/popin/domain/popup/service/PopupSearchService.java
+++ b/src/main/java/com/snow/popin/domain/popup/service/PopupSearchService.java
@@ -7,10 +7,7 @@ import com.snow.popin.domain.popup.entity.PopupImage;
 import com.snow.popin.domain.popup.repository.PopupSearchRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,20 +23,23 @@ public class PopupSearchService {
 
     private final PopupSearchRepository popupSearchRepository;
 
+    /**
+     * 팝업 검색 (제목 + 태그)
+     */
     public PopupListResponseDto searchPopups(PopupSearchRequestDto request) {
-        log.info("팝업 검색 시작 - 검색어: {}, 페이지: {}, 크기: {}",
-                request.getQuery(), request.getPage(), request.getSize());
-
-        Pageable pageable = createSearchPageable(request.getPage(), request.getSize());
         String query = preprocessQuery(request.getQuery());
 
-        // 검색어 길이 체크 (최소 2글자)
+        // 2글자 미만이면 빈 결과 반환
         if (query == null || query.length() < 2) {
-            log.info("검색어 최소 길이 미충족 - 검색어: '{}', 길이: {}",
+            log.info("검색어 길이 부족 - query: '{}', length: {}",
                     request.getQuery(), query != null ? query.length() : 0);
-            return PopupListResponseDto.of(new org.springframework.data.domain.PageImpl<>(List.of(), pageable, 0), List.of());
+            return createEmptyResult(request);
         }
 
+        log.info("팝업 검색 - query: '{}', page: {}, size: {}",
+                query, request.getPage(), request.getSize());
+
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
         Page<Popup> popupPage = popupSearchRepository.searchByTitleAndTags(query, pageable);
 
         List<PopupSummaryResponseDto> popupDtos = popupPage.getContent()
@@ -47,131 +47,54 @@ public class PopupSearchService {
                 .map(PopupSummaryResponseDto::from)
                 .collect(Collectors.toList());
 
-        log.info("팝업 검색 완료 - 검색어: {}, 결과 수: {}", query, popupPage.getTotalElements());
-
+        log.info("팝업 검색 완료 - 결과: {}개", popupPage.getTotalElements());
         return PopupListResponseDto.of(popupPage, popupDtos);
     }
 
-    // 자동완성 리스트 조회
-    // 팝업 제목과 태그에서 검색어와 일치하는 항목들을 찾아서 반환
+    /**
+     * 자동완성 제안 조회
+     */
     public AutocompleteResponseDto getAutocompleteSuggestions(String query) {
-        log.info("자동완성 제안 조회 - 검색어: {}", query);
+        String processedQuery = preprocessQuery(query);
 
-        // 검색어 전처리
-        String preprocessedQuery = preprocessQuery(query);
-
-        // 검색어가 너무 짧으면 빈 결과 반환
-        if (preprocessedQuery == null || preprocessedQuery.length() < 1) {
-            log.info("자동완성 검색어 길이 부족 - 검색어: {}", query);
+        // 1글자 미만이면 빈 결과 반환
+        if (processedQuery == null || processedQuery.length() < 1) {
             return AutocompleteResponseDto.empty(query);
         }
 
-        try {
-            // 통합 검색어 제안 조회 (최대 10개)
-            List<Object[]> rawSuggestions = popupSearchRepository.findSuggestions(preprocessedQuery, 10);
+        log.info("자동완성 조회 - query: '{}'", processedQuery);
 
-            List<AutocompleteSuggestionDto> suggestions = rawSuggestions.stream()
-                    .map(this::convertToSuggestionDto)
-                    .filter(Objects::nonNull)
+        try {
+            List<String> suggestions = popupSearchRepository.findSuggestions(processedQuery, 8);
+
+            List<AutocompleteSuggestionDto> suggestionDtos = suggestions.stream()
+                    .map(suggestion -> AutocompleteSuggestionDto.of(suggestion, "suggestion", 0L))
                     .collect(Collectors.toList());
 
-            log.info("자동완성 제안 완료 - 검색어: {}, 결과 수: {}", query, suggestions.size());
-            return AutocompleteResponseDto.of(suggestions, query);
+            log.info("자동완성 완료 - 결과: {}개", suggestionDtos.size());
+            return AutocompleteResponseDto.of(suggestionDtos, query);
 
         } catch (Exception e) {
-            log.error("자동완성 제안 조회 실패 - 검색어: {}", query, e);
+            log.error("자동완성 조회 실패 - query: '{}'", query, e);
             return AutocompleteResponseDto.empty(query);
         }
     }
 
-    // 간단한 자동완성 조회
-    public AutocompleteResponseDto getSimpleAutocompleteSuggestions(String query) {
-        log.info("간단한 자동완성 제안 조회 - 검색어: {}", query);
-
-        String preprocessedQuery = preprocessQuery(query);
-
-        if (preprocessedQuery == null || preprocessedQuery.length() < 1) {
-            return AutocompleteResponseDto.empty(query);
-        }
-
-        try {
-            Pageable limitPageable = PageRequest.of(0, 10); // 최대 10개씩
-
-            // 팝업 제목에서 자동완성 리스트 가져오기
-            List<String> titleSuggestions = popupSearchRepository.findPopupTitleSuggestions(preprocessedQuery, limitPageable);
-            log.info("제목 제안 결과 - 검색어: {}, 결과: {}", preprocessedQuery, titleSuggestions);
-
-            // 태그에서 자동완성 리스트 가져오기
-            List<String> tagSuggestions = popupSearchRepository.findTagSuggestions(preprocessedQuery, limitPageable);
-            log.info("태그 제안 결과 - 검색어: {}, 결과: {}", preprocessedQuery, tagSuggestions);
-
-            // 자동완성 리스트 조합 및 중복 제거
-            Set<String> allSuggestions = new LinkedHashSet<>();
-            allSuggestions.addAll(titleSuggestions);
-            allSuggestions.addAll(tagSuggestions);
-
-            log.info("통합 제안 결과 - 검색어: {}, 중복 제거 후: {}", preprocessedQuery, allSuggestions);
-
-            List<AutocompleteSuggestionDto> suggestions = allSuggestions.stream()
-                    .limit(8) // 최대 8개
-                    .map(suggestion -> {
-                        String type = titleSuggestions.contains(suggestion) ? "title" : "tag";
-                        return AutocompleteSuggestionDto.of(suggestion, type, 0L);
-                    })
-                    .collect(Collectors.toList());
-
-            log.info("간단한 자동완성 제안 완료 - 검색어: {}, 결과 수: {}", query, suggestions.size());
-            if (!suggestions.isEmpty()) {
-                log.info("반환될 제안들: {}", suggestions.stream()
-                        .map(s -> s.getText() + "(" + s.getType() + ")")
-                        .collect(Collectors.toList()));
-            }
-
-            return AutocompleteResponseDto.of(suggestions, query);
-
-        } catch (Exception e) {
-            log.error("간단한 자동완성 제안 조회 실패 - 검색어: {}", query, e);
-            return AutocompleteResponseDto.empty(query);
-        }
-    }
-
+    /**
+     * 검색어 전처리
+     */
     private String preprocessQuery(String query) {
         if (query == null) {
             return null;
         }
-
-        return query.trim()
-                .replaceAll("\\s+", " ")
-                .toLowerCase();
+        return query.trim().replaceAll("\\s+", " ");
     }
 
-    private Pageable createSearchPageable(int page, int size) {
-        int validPage = Math.max(0, page);
-        int validSize = Math.min(Math.max(1, size), 100);
-        return PageRequest.of(validPage, validSize, Sort.by(Sort.Direction.DESC, "createdAt"));
-    }
-
-    private AutocompleteSuggestionDto convertToSuggestionDto(Object[] row) {
-        try {
-            String suggestion = (String) row[0];
-            String type = (String) row[1];
-
-            // popularity는 BigInteger 또는 Long일 수 있음
-            Long popularity = 0L;
-            if (row[2] != null) {
-                if (row[2] instanceof BigInteger) {
-                    popularity = ((BigInteger) row[2]).longValue();
-                } else if (row[2] instanceof Long) {
-                    popularity = (Long) row[2];
-                } else if (row[2] instanceof Integer) {
-                    popularity = ((Integer) row[2]).longValue();
-                }
-            }
-
-            return AutocompleteSuggestionDto.of(suggestion, type, popularity);
-        } catch (Exception e) {
-            log.warn("자동완성 제안 변환 실패: {}", Arrays.toString(row), e);
-            return null;
-        }
+    /**
+     * 빈 검색 결과 생성
+     */
+    private PopupListResponseDto createEmptyResult(PopupSearchRequestDto request) {
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
+        return PopupListResponseDto.of(Page.empty(pageable), List.of());
     }
 }

--- a/src/main/java/com/snow/popin/domain/popup/service/PopupSearchService.java
+++ b/src/main/java/com/snow/popin/domain/popup/service/PopupSearchService.java
@@ -1,9 +1,7 @@
 package com.snow.popin.domain.popup.service;
 
 import com.snow.popin.domain.popup.dto.request.PopupSearchRequestDto;
-import com.snow.popin.domain.popup.dto.response.PopupImageResponseDto;
-import com.snow.popin.domain.popup.dto.response.PopupListResponseDto;
-import com.snow.popin.domain.popup.dto.response.PopupSummaryResponseDto;
+import com.snow.popin.domain.popup.dto.response.*;
 import com.snow.popin.domain.popup.entity.Popup;
 import com.snow.popin.domain.popup.entity.PopupImage;
 import com.snow.popin.domain.popup.repository.PopupSearchRepository;
@@ -16,7 +14,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.math.BigInteger;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -34,8 +33,10 @@ public class PopupSearchService {
         Pageable pageable = createSearchPageable(request.getPage(), request.getSize());
         String query = preprocessQuery(request.getQuery());
 
+        // 검색어 길이 체크 (최소 2글자)
         if (query == null || query.length() < 2) {
-           log.info("검색어 최소 길이 미충족 - 검색어: {}", request.getQuery());
+            log.info("검색어 최소 길이 미충족 - 검색어: '{}', 길이: {}",
+                    request.getQuery(), query != null ? query.length() : 0);
             return PopupListResponseDto.of(new org.springframework.data.domain.PageImpl<>(List.of(), pageable, 0), List.of());
         }
 
@@ -49,6 +50,89 @@ public class PopupSearchService {
         log.info("팝업 검색 완료 - 검색어: {}, 결과 수: {}", query, popupPage.getTotalElements());
 
         return PopupListResponseDto.of(popupPage, popupDtos);
+    }
+
+    // 자동완성 리스트 조회
+    // 팝업 제목과 태그에서 검색어와 일치하는 항목들을 찾아서 반환
+    public AutocompleteResponseDto getAutocompleteSuggestions(String query) {
+        log.info("자동완성 제안 조회 - 검색어: {}", query);
+
+        // 검색어 전처리
+        String preprocessedQuery = preprocessQuery(query);
+
+        // 검색어가 너무 짧으면 빈 결과 반환
+        if (preprocessedQuery == null || preprocessedQuery.length() < 1) {
+            log.info("자동완성 검색어 길이 부족 - 검색어: {}", query);
+            return AutocompleteResponseDto.empty(query);
+        }
+
+        try {
+            // 통합 검색어 제안 조회 (최대 10개)
+            List<Object[]> rawSuggestions = popupSearchRepository.findSuggestions(preprocessedQuery, 10);
+
+            List<AutocompleteSuggestionDto> suggestions = rawSuggestions.stream()
+                    .map(this::convertToSuggestionDto)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+
+            log.info("자동완성 제안 완료 - 검색어: {}, 결과 수: {}", query, suggestions.size());
+            return AutocompleteResponseDto.of(suggestions, query);
+
+        } catch (Exception e) {
+            log.error("자동완성 제안 조회 실패 - 검색어: {}", query, e);
+            return AutocompleteResponseDto.empty(query);
+        }
+    }
+
+    // 간단한 자동완성 조회
+    public AutocompleteResponseDto getSimpleAutocompleteSuggestions(String query) {
+        log.info("간단한 자동완성 제안 조회 - 검색어: {}", query);
+
+        String preprocessedQuery = preprocessQuery(query);
+
+        if (preprocessedQuery == null || preprocessedQuery.length() < 1) {
+            return AutocompleteResponseDto.empty(query);
+        }
+
+        try {
+            Pageable limitPageable = PageRequest.of(0, 10); // 최대 10개씩
+
+            // 팝업 제목에서 자동완성 리스트 가져오기
+            List<String> titleSuggestions = popupSearchRepository.findPopupTitleSuggestions(preprocessedQuery, limitPageable);
+            log.info("제목 제안 결과 - 검색어: {}, 결과: {}", preprocessedQuery, titleSuggestions);
+
+            // 태그에서 자동완성 리스트 가져오기
+            List<String> tagSuggestions = popupSearchRepository.findTagSuggestions(preprocessedQuery, limitPageable);
+            log.info("태그 제안 결과 - 검색어: {}, 결과: {}", preprocessedQuery, tagSuggestions);
+
+            // 자동완성 리스트 조합 및 중복 제거
+            Set<String> allSuggestions = new LinkedHashSet<>();
+            allSuggestions.addAll(titleSuggestions);
+            allSuggestions.addAll(tagSuggestions);
+
+            log.info("통합 제안 결과 - 검색어: {}, 중복 제거 후: {}", preprocessedQuery, allSuggestions);
+
+            List<AutocompleteSuggestionDto> suggestions = allSuggestions.stream()
+                    .limit(8) // 최대 8개
+                    .map(suggestion -> {
+                        String type = titleSuggestions.contains(suggestion) ? "title" : "tag";
+                        return AutocompleteSuggestionDto.of(suggestion, type, 0L);
+                    })
+                    .collect(Collectors.toList());
+
+            log.info("간단한 자동완성 제안 완료 - 검색어: {}, 결과 수: {}", query, suggestions.size());
+            if (!suggestions.isEmpty()) {
+                log.info("반환될 제안들: {}", suggestions.stream()
+                        .map(s -> s.getText() + "(" + s.getType() + ")")
+                        .collect(Collectors.toList()));
+            }
+
+            return AutocompleteResponseDto.of(suggestions, query);
+
+        } catch (Exception e) {
+            log.error("간단한 자동완성 제안 조회 실패 - 검색어: {}", query, e);
+            return AutocompleteResponseDto.empty(query);
+        }
     }
 
     private String preprocessQuery(String query) {
@@ -65,5 +149,29 @@ public class PopupSearchService {
         int validPage = Math.max(0, page);
         int validSize = Math.min(Math.max(1, size), 100);
         return PageRequest.of(validPage, validSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+
+    private AutocompleteSuggestionDto convertToSuggestionDto(Object[] row) {
+        try {
+            String suggestion = (String) row[0];
+            String type = (String) row[1];
+
+            // popularity는 BigInteger 또는 Long일 수 있음
+            Long popularity = 0L;
+            if (row[2] != null) {
+                if (row[2] instanceof BigInteger) {
+                    popularity = ((BigInteger) row[2]).longValue();
+                } else if (row[2] instanceof Long) {
+                    popularity = (Long) row[2];
+                } else if (row[2] instanceof Integer) {
+                    popularity = ((Integer) row[2]).longValue();
+                }
+            }
+
+            return AutocompleteSuggestionDto.of(suggestion, type, popularity);
+        } catch (Exception e) {
+            log.warn("자동완성 제안 변환 실패: {}", Arrays.toString(row), e);
+            return null;
+        }
     }
 }

--- a/src/main/resources/static/css/popup-search.css
+++ b/src/main/resources/static/css/popup-search.css
@@ -101,6 +101,7 @@
     gap: 16px;
     padding: 8px 20px;
     cursor: pointer;
+    transition: background-color 0.15s ease;
 }
 
 .autocomplete-item:hover,
@@ -118,10 +119,7 @@
 .autocomplete-text {
     font-size: 15px;
     color: #374151;
-}
-.autocomplete-text .highlight {
-    font-weight: 600;
-    color: #1f2937;
+    width: 100%;
 }
 
 /* 검색 결과 */
@@ -129,9 +127,8 @@
     margin-top: 24px;
     background: white;
     border-radius: 12px;
-    padding: 20px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    display: none; /* 기본적으로 숨김 */
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    display: none;
 }
 
 .search-results.show {
@@ -139,70 +136,140 @@
 }
 
 .search-results-title {
-    font-size: 18px;
-    font-weight: 700;
-    color: #1f2937;
-    margin-bottom: 16px;
+    padding: 20px 24px 16px;
+    font-size: 16px;
+    font-weight: 600;
+    color: #374151;
+    border-bottom: 1px solid #e5e7eb;
 }
 
 .search-results-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 20px;
+    padding: 20px;
 }
 
-/* 검색 결과 없음 */
-.no-results {
+.popup-card {
+    background: white;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
+    cursor: pointer;
+}
+
+.popup-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.popup-image {
+    width: 100%;
+    height: 180px;
+    overflow: hidden;
+}
+
+.popup-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.popup-info {
+    padding: 16px;
+}
+
+.popup-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0 0 8px 0;
+    line-height: 1.4;
+}
+
+.popup-region,
+.popup-period {
+    font-size: 14px;
+    color: #6b7280;
+    margin: 4px 0;
+}
+
+/* 검색 결과 없음 및 에러 */
+.no-results,
+.search-error {
     text-align: center;
-    padding: 40px 20px;
+    padding: 60px 20px;
     color: #6b7280;
 }
 
-.no-results-icon {
-    width: 48px;
-    height: 48px;
-    margin: 0 auto 16px;
-    color: #d1d5db;
+.no-results-icon,
+.error-icon {
+    font-size: 48px;
+    margin-bottom: 16px;
+    opacity: 0.5;
 }
 
-.no-results-title {
+.no-results h3,
+.search-error h3 {
     font-size: 18px;
     font-weight: 600;
-    margin-bottom: 8px;
+    margin: 0 0 8px 0;
     color: #374151;
 }
 
-.no-results-desc {
+.no-results p,
+.search-error p {
     font-size: 14px;
+    margin: 4px 0;
     line-height: 1.5;
 }
 
 /* 로딩 */
 .loading-container {
-    display: flex;
+    display: none;
+    align-items: center;
     justify-content: center;
     padding: 40px;
+    color: #6b7280;
 }
 
-/* 반응형 */
-@media (max-width: 375px) {
+.loading {
+    width: 20px;
+    height: 20px;
+    border: 2px solid #e5e7eb;
+    border-top: 2px solid #4b5ae4;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+/* 모바일 대응 */
+@media (max-width: 768px) {
     .popup-search-container {
         padding: 16px;
     }
 
-    .search-input-wrapper {
-        padding: 14px 16px;
-    }
-
-    .search-input {
-        font-size: 16px;
-    }
-
-    .related-searches {
-        padding: 0 16px 16px 16px;
+    .search-area {
+        max-width: 100%;
     }
 
     .search-results-grid {
-        gap: 12px;
+        grid-template-columns: 1fr;
+        gap: 16px;
+        padding: 16px;
+    }
+
+    .autocomplete-item {
+        padding: 10px 16px;
+    }
+
+    .autocomplete-text {
+        font-size: 14px;
     }
 }

--- a/src/main/resources/static/css/popup-search.css
+++ b/src/main/resources/static/css/popup-search.css
@@ -6,7 +6,7 @@
 /* 검색 영역 전체 컨테이너 */
 .search-area {
     position: relative;
-    max-width: 580px; /* 구글과 유사한 기본 너비 */
+    max-width: 580px;
     margin: 0 auto;
     transition: max-width 0.3s ease;
 }
@@ -25,7 +25,7 @@
     gap: 12px;
     background: white;
     border: 1px solid rgba(0, 0, 0, 0.1);
-    border-radius: 24px; /* 둥근 형태 */
+    border-radius: 24px;
     padding: 12px 20px;
     box-shadow: 0 1px 6px rgba(32,33,36,0.1);
     transition: all 0.2s ease;
@@ -74,7 +74,7 @@
 
 /* 자동완성 드롭다운 */
 .related-searches {
-    display: none; /* 기본 숨김 */
+    display: none;
     position: absolute;
     top: 100%;
     left: 0;
@@ -143,56 +143,86 @@
     border-bottom: 1px solid #e5e7eb;
 }
 
+/* 검색 결과 그리드 */
 .search-results-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 20px;
-    padding: 20px;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+    padding: 16px 24px 28px;
+    max-width: 100%;
 }
 
+/* 팝업 카드 */
 .popup-card {
     background: white;
     border-radius: 12px;
     overflow: hidden;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    transition: all 0.2s ease;
+    box-shadow: none;
     cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    aspect-ratio: 0.7;
 }
 
 .popup-card:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 8px 24px rgba(0,0,0,0.08);
 }
 
-.popup-image {
+/* 이미지 래퍼 */
+.card-image-wrapper {
     width: 100%;
-    height: 180px;
+    height: 80%;
+    position: relative;
     overflow: hidden;
 }
 
-.popup-image img {
+/* 이미지 스타일 */
+.card-image {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    border-radius: 12px;
+    display: block;
 }
 
-.popup-info {
-    padding: 16px;
+/* 카드 콘텐츠 */
+.card-content {
+    padding: 14px 10px 4px;
+    height: 24%;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    gap: 5px;
 }
 
-.popup-title {
+/* 카드 제목 */
+.card-title {
     font-size: 16px;
-    font-weight: 600;
+    font-weight: 700;
     color: #1f2937;
-    margin: 0 0 8px 0;
-    line-height: 1.4;
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.2;
 }
 
-.popup-region,
-.popup-period {
-    font-size: 14px;
+/* 카드 정보 */
+.card-info {
+    font-size: 12px;
     color: #6b7280;
-    margin: 4px 0;
+    line-height: 1.1;
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.card-info.location {
+    margin-top: 1px;
 }
 
 /* 검색 결과 없음 및 에러 */
@@ -201,6 +231,7 @@
     text-align: center;
     padding: 60px 20px;
     color: #6b7280;
+    grid-column: 1 / -1;
 }
 
 .no-results-icon,
@@ -249,6 +280,22 @@
     }
 }
 
+/* 태블릿 대응 */
+@media (max-width: 1024px) {
+    .popup-search-container {
+        padding: 20px;
+    }
+
+    .search-results-grid {
+        gap: 16px;
+        padding: 16px;
+    }
+
+    .popup-image {
+        height: 160px;
+    }
+}
+
 /* 모바일 대응 */
 @media (max-width: 768px) {
     .popup-search-container {
@@ -265,11 +312,44 @@
         padding: 16px;
     }
 
+    .popup-image {
+        height: 200px;
+    }
+
+    .popup-info {
+        padding: 14px;
+    }
+
+    .popup-title {
+        font-size: 15px;
+    }
+
+    .popup-region,
+    .popup-period {
+        font-size: 13px;
+    }
+
     .autocomplete-item {
         padding: 10px 16px;
     }
 
     .autocomplete-text {
         font-size: 14px;
+    }
+}
+
+/* 작은 모바일 대응 */
+@media (max-width: 480px) {
+    .popup-search-container {
+        padding: 12px;
+    }
+
+    .search-results-grid {
+        padding: 12px;
+        gap: 12px;
+    }
+
+    .popup-image {
+        height: 160px;
     }
 }

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -411,6 +411,23 @@ apiService.searchPopups = async function(params = {}) {
     return await this.get(`/search/popups${query}`);
 };
 
+// 자동완성 제안 조회
+apiService.getAutocompleteSuggestions = async function(query) {
+    try {
+        if (!query || query.trim().length < 1) {
+            return { suggestions: [], query: query || '', totalCount: 0 };
+        }
+
+        const encodedQuery = encodeURIComponent(query.trim());
+        const response = await this.get(`/search/suggestions?q=${encodedQuery}`);
+
+        return response || { suggestions: [], query: query, totalCount: 0 };
+    } catch (error) {
+        console.warn('자동완성 제안 조회 실패:', error);
+        return { suggestions: [], query: query || '', totalCount: 0 };
+    }
+};
+
 // 지역 목록 조회
 apiService.getMapRegions = async function() {
     return await this.get('/map/regions');

--- a/src/main/resources/static/js/popup-search.js
+++ b/src/main/resources/static/js/popup-search.js
@@ -1,4 +1,4 @@
-// 팝업 검색 페이지 전용 모듈
+// 팝업 검색 페이지 전용 모듈 (개선된 버전)
 class PopupSearchManager {
     constructor() {
         this.searchInput = null;
@@ -6,20 +6,31 @@ class PopupSearchManager {
         this.relatedSearches = null;
         this.searchResults = null;
         this.searchLoading = null;
-        this.currentQuery = '';
-        this.isSearching = false;
-        this.selectedIndex = -1;
+
+        // 상태 관리
+        this.state = {
+            currentQuery: '',
+            isSearching: false,
+            selectedIndex: -1,
+            isLoadingSuggestions: false,
+            isShowingAlert: false
+        };
+
+        // 자동완성 관련
         this.autocompleteItems = [];
         this.debounceTimeout = null;
-        this.autocompleteCache = new Map(); // 자동완성 캐시
-        this.isLoadingSuggestions = false; // 자동완성 로딩 상태
-        this.isShowingAlert = false; // alert 표시 중 플래그
+        this.autocompleteCache = new Map();
+
+        // 상수
+        this.MIN_SEARCH_LENGTH = 2;
+        this.MIN_AUTOCOMPLETE_LENGTH = 1;
+        this.DEBOUNCE_DELAY = 300;
+        this.MAX_CACHE_SIZE = 50;
     }
 
     // 페이지 초기화
     async initialize() {
         try {
-            // HTML이 이미 있는지 확인
             if (!this.checkExistingHTML()) {
                 await this.renderHTML();
             }
@@ -51,7 +62,8 @@ class PopupSearchManager {
                 <div class="popup-search-container">
                     <div class="search-area">
                         <div class="search-input-wrapper">
-                            <input type="text" id="popup-search-input" class="search-input" placeholder="검색어를 입력하세요" autocomplete="off">
+                            <input type="text" id="popup-search-input" class="search-input" 
+                                   placeholder="검색어를 입력하세요" autocomplete="off">
                             <button class="search-button" id="popup-search-button">
                                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                     <circle cx="11" cy="11" r="8"></circle>
@@ -77,7 +89,6 @@ class PopupSearchManager {
         this.searchResults = document.getElementById('popup-search-results');
         this.searchLoading = document.getElementById('popup-search-loading');
 
-        // 요소가 없으면 오류 발생
         if (!this.searchInput || !this.searchButton) {
             throw new Error('필수 DOM 요소를 찾을 수 없습니다.');
         }
@@ -85,25 +96,29 @@ class PopupSearchManager {
 
     // 이벤트 리스너 설정
     setupEventListeners() {
-        // 버튼 클릭 이벤트 (중복 방지)
+        // 검색 버튼 클릭
         this.searchButton.addEventListener('click', () => {
-            if (this.isShowingAlert) return; // alert 표시 중이면 무시
-            this.performSearch();
+            if (!this.state.isShowingAlert) {
+                this.performSearch();
+            }
         });
 
+        // 키보드 이벤트
         this.searchInput.addEventListener('keydown', this.handleKeyDown.bind(this));
 
+        // 입력 이벤트 (디바운싱)
         this.searchInput.addEventListener('input', this.handleInput.bind(this));
 
+        // 포커스 이벤트
         this.searchInput.addEventListener('focus', () => {
             const query = this.searchInput.value.trim();
-            if (query.length > 0) {
+            if (query.length >= this.MIN_AUTOCOMPLETE_LENGTH) {
                 this.loadAutocompleteSuggestions(query);
             }
         });
 
+        // 블러 이벤트
         this.searchInput.addEventListener('blur', (e) => {
-            // 자동완성 항목 클릭을 위해 약간의 지연 추가
             setTimeout(() => {
                 if (!e.relatedTarget || !e.relatedTarget.closest('.related-searches')) {
                     this.hideAutocomplete();
@@ -111,61 +126,60 @@ class PopupSearchManager {
             }, 150);
         });
 
+        // 외부 클릭 시 자동완성 숨김
         document.addEventListener('click', (e) => {
             if (!e.target.closest('.search-area')) {
                 this.hideAutocomplete();
             }
         });
 
-        // 자동완성 클릭 이벤트 (중복 방지)
+        // 자동완성 항목 클릭
         if (this.relatedSearches) {
             this.relatedSearches.addEventListener('click', (e) => {
-                if (this.isShowingAlert) return; // alert 표시 중이면 무시
+                if (this.state.isShowingAlert) return;
 
                 const item = e.target.closest('.autocomplete-item');
                 if (item) {
-                    // data-suggestion 속성에서 정확한 텍스트 가져오기
                     const suggestionText = item.dataset.suggestion;
-                    console.log('자동완성 클릭:', suggestionText); // 디버깅 로그
                     this.searchInput.value = suggestionText;
                     this.hideAutocomplete();
-
-                    // 자동완성 선택시에는 길이 제한 없이 바로 검색
                     this.performSearchFromAutocomplete(suggestionText);
                 }
             });
         }
 
+        // 검색 결과 클릭
         if (this.searchResults) {
             this.searchResults.addEventListener('click', (e) => {
                 const card = e.target.closest('.popup-card');
-                if (!card) return;
-                const popupId = card.dataset.popupId;
-                if (popupId) goToPopupDetail(popupId);
+                if (card) {
+                    const popupId = card.dataset.popupId;
+                    if (popupId) goToPopupDetail(popupId);
+                }
             });
         }
     }
 
-    // 입력 처리를 위한 디바운싱 핸들러 (API 호출 버전)
+    // 입력 처리 (디바운싱)
     handleInput() {
         clearTimeout(this.debounceTimeout);
         this.debounceTimeout = setTimeout(() => {
             const query = this.searchInput.value.trim();
-            if (query && query.length >= 1) {
+            if (query && query.length >= this.MIN_AUTOCOMPLETE_LENGTH) {
                 this.loadAutocompleteSuggestions(query);
             } else {
                 this.hideAutocomplete();
                 this.hideSearchResults();
             }
-        }, 300); // 300ms 지연
+        }, this.DEBOUNCE_DELAY);
     }
 
-    // 서버에서 자동완성 제안 로드
+    // 자동완성 제안 로드
     async loadAutocompleteSuggestions(query) {
-        if (this.isLoadingSuggestions) return;
+        if (this.state.isLoadingSuggestions) return;
 
         try {
-            this.isLoadingSuggestions = true;
+            this.state.isLoadingSuggestions = true;
 
             // 캐시 확인
             if (this.autocompleteCache.has(query)) {
@@ -177,25 +191,28 @@ class PopupSearchManager {
             // API 호출
             const response = await apiService.getAutocompleteSuggestions(query);
 
-            // 캐시에 저장 (최대 50개 항목)
-            if (this.autocompleteCache.size >= 50) {
+            // 응답 구조 확인 및 처리
+            const suggestions = response?.suggestions || [];
+
+            // 캐시 저장
+            if (this.autocompleteCache.size >= this.MAX_CACHE_SIZE) {
                 const firstKey = this.autocompleteCache.keys().next().value;
                 this.autocompleteCache.delete(firstKey);
             }
-            this.autocompleteCache.set(query, response.suggestions);
+            this.autocompleteCache.set(query, suggestions);
 
             // 결과 표시
-            this.displayAutocompleteSuggestions(response.suggestions, query);
+            this.displayAutocompleteSuggestions(suggestions, query);
 
         } catch (error) {
             console.error('자동완성 제안 로드 실패:', error);
             this.hideAutocomplete();
         } finally {
-            this.isLoadingSuggestions = false;
+            this.state.isLoadingSuggestions = false;
         }
     }
 
-    // 자동완성 제안 표시 (아이콘 제거, 단순화)
+    // 자동완성 제안 표시
     displayAutocompleteSuggestions(suggestions, query) {
         if (!this.relatedSearches || !suggestions || suggestions.length === 0) {
             this.hideAutocomplete();
@@ -206,48 +223,42 @@ class PopupSearchManager {
         this.searchInput.closest('.search-area').classList.add('active');
 
         this.relatedSearches.innerHTML = suggestions.map(suggestion => {
+            // suggestion이 문자열일 수도 있고 객체일 수도 있음
+            const text = typeof suggestion === 'string' ? suggestion : suggestion.text;
             return `
-                <div class="autocomplete-item" data-suggestion="${this.escapeHtml(suggestion.text)}">
+                <div class="autocomplete-item" data-suggestion="${this.escapeHtml(text)}">
                     <svg class="autocomplete-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <circle cx="11" cy="11" r="8"></circle>
                         <path d="m21 21-4.35-4.35"></path>
                     </svg>
-                    <div class="autocomplete-text">${this.escapeHtml(suggestion.text)}</div>
+                    <div class="autocomplete-text">${this.escapeHtml(text)}</div>
                 </div>`;
         }).join('');
 
         this.autocompleteItems = this.relatedSearches.querySelectorAll('.autocomplete-item');
         this.relatedSearches.classList.add('show');
-        this.selectedIndex = -1;
+        this.state.selectedIndex = -1;
     }
 
-    // 키보드 이벤트 (중복 alert 방지)
+    // 키보드 이벤트 처리
     handleKeyDown(e) {
-        console.log('키보드 이벤트:', e.key, '| alert 상태:', this.isShowingAlert); // 디버깅 로그
-
-        // alert가 표시 중이면 이벤트 무시
-        if (this.isShowingAlert) {
-            console.log('alert 표시 중이므로 키보드 이벤트 무시');
-            return;
-        }
+        if (this.state.isShowingAlert) return;
 
         const isAutocompleteVisible = this.relatedSearches && this.relatedSearches.classList.contains('show');
 
         switch (e.key) {
             case 'Enter':
                 e.preventDefault();
-                if (this.selectedIndex > -1 && this.autocompleteItems[this.selectedIndex]) {
-                    // 자동완성에서 선택한 경우 - 길이 체크 없이 바로 검색
-                    const suggestion = this.autocompleteItems[this.selectedIndex].dataset.suggestion;
-                    console.log('자동완성 키보드 선택:', suggestion);
+                if (this.state.selectedIndex > -1 && this.autocompleteItems[this.state.selectedIndex]) {
+                    // 자동완성에서 선택한 경우
+                    const suggestion = this.autocompleteItems[this.state.selectedIndex].dataset.suggestion;
                     this.searchInput.value = suggestion;
                     this.hideAutocomplete();
                     this.performSearchFromAutocomplete(suggestion);
                 } else {
-                    // 직접 입력한 경우 - 길이 체크 수행
-                    console.log('직접 입력 엔터 검색');
+                    // 직접 입력한 경우
                     this.hideAutocomplete();
-                    this.performSearch(); // 여기서 길이 체크가 수행됨
+                    this.performSearch();
                 }
                 break;
             case 'ArrowDown':
@@ -268,98 +279,51 @@ class PopupSearchManager {
         }
     }
 
-    // 자동완성 숨김
-    hideAutocomplete() {
-        if (this.relatedSearches) {
-            this.relatedSearches.classList.remove('show');
-            this.searchInput.closest('.search-input-wrapper').classList.remove('autocomplete-active');
-            this.searchInput.closest('.search-area').classList.remove('active');
-        }
-        this.autocompleteItems = [];
-        this.selectedIndex = -1;
-    }
-
-    // 키보드로 자동완성 네비게이션
+    // 자동완성 네비게이션
     navigateAutocomplete(direction) {
         if (this.autocompleteItems.length === 0) return;
 
-        this.autocompleteItems[this.selectedIndex]?.classList.remove('selected');
-        this.selectedIndex = (this.selectedIndex + direction + this.autocompleteItems.length) % this.autocompleteItems.length;
-        this.autocompleteItems[this.selectedIndex].classList.add('selected');
-        this.autocompleteItems[this.selectedIndex].scrollIntoView({ block: 'nearest' });
+        this.autocompleteItems[this.state.selectedIndex]?.classList.remove('selected');
+        this.state.selectedIndex = (this.state.selectedIndex + direction + this.autocompleteItems.length) % this.autocompleteItems.length;
+        this.autocompleteItems[this.state.selectedIndex].classList.add('selected');
+        this.autocompleteItems[this.state.selectedIndex].scrollIntoView({ block: 'nearest' });
     }
 
-    // 자동완성에서 선택했을 때의 검색 (길이 제한 없음, 중복 방지)
+    // 자동완성에서 선택했을 때의 검색 (길이 제한 없음)
     async performSearchFromAutocomplete(searchQuery) {
-        if (!searchQuery || this.isSearching || this.isShowingAlert) return;
+        if (!searchQuery || this.state.isSearching || this.state.isShowingAlert) return;
 
-        console.log('자동완성 검색 수행:', searchQuery);
-
-        this.currentQuery = searchQuery;
-        this.isSearching = true;
+        this.state.currentQuery = searchQuery;
+        this.state.isSearching = true;
 
         this.hideAutocomplete();
         this.showLoading();
         this.hideSearchResults();
 
         try {
-            const params = {
-                query: searchQuery,
-                page: 0,
-                size: 20
-            };
+            const params = { query: searchQuery, page: 0, size: 20 };
             const response = await apiService.searchPopups(params);
             this.displaySearchResults(response);
         } catch (error) {
             console.error('자동완성 검색 실패:', error);
             this.showSearchError();
         } finally {
-            this.isSearching = false;
+            this.state.isSearching = false;
             this.hideLoading();
         }
     }
 
-    // 검색 수행 (중복 alert 방지)
+    // 일반 검색 수행 (길이 체크 포함)
     async performSearch(searchParams = {}) {
         const searchQuery = searchParams.query || this.searchInput.value.trim();
-        console.log('performSearch 호출 - 검색어:', searchQuery, '| alert 상태:', this.isShowingAlert);
 
-        // 검색어 길이 체크 (최소 2글자)
-        if (!searchQuery || searchQuery.length < 2) {
-            console.log('검색어 길이 부족:', searchQuery);
+        // 검색어 길이 체크
+        if (!this.validateSearchQuery(searchQuery)) return;
+        if (this.state.isSearching) return;
 
-            if (searchQuery.length === 1) {
-                // alert 중복 방지
-                if (this.isShowingAlert) {
-                    console.log('이미 alert 표시 중 - 무시');
-                    return;
-                }
+        this.state.currentQuery = searchQuery;
+        this.state.isSearching = true;
 
-                console.log('alert 표시 시작');
-                this.isShowingAlert = true;
-                alert('검색어를 2글자 이상 입력해주세요.');
-
-                // alert 닫힌 후 포커스 복원 및 상태 해제
-                setTimeout(() => {
-                    console.log('alert 상태 해제');
-                    this.isShowingAlert = false;
-                    this.searchInput.focus(); // 포커스 복원
-                }, 200);
-                return;
-            } else if (!searchQuery) {
-                // 빈 검색어일 때는 조용히 무시
-                return;
-            }
-        }
-
-        if (this.isSearching) return;
-
-        console.log('정상 검색 수행:', searchQuery); // 디버깅 로그
-
-        this.currentQuery = searchQuery;
-        this.isSearching = true;
-
-        // 검색 시작 시 자동완성 및 기타 UI 숨김
         this.hideAutocomplete();
         this.showLoading();
         this.hideSearchResults();
@@ -370,34 +334,58 @@ class PopupSearchManager {
                 page: searchParams.page || 0,
                 size: searchParams.size || 20
             };
-            console.log('검색 파라미터:', params); // 디버깅 로그
             const response = await apiService.searchPopups(params);
             this.displaySearchResults(response);
         } catch (error) {
             console.error('팝업 검색 실패:', error);
             this.showSearchError();
         } finally {
-            this.isSearching = false;
+            this.state.isSearching = false;
             this.hideLoading();
         }
     }
 
+    // 검색어 유효성 검사
+    validateSearchQuery(query) {
+        if (!query || query.length < this.MIN_SEARCH_LENGTH) {
+            if (query && query.length === 1) {
+                this.showLengthAlert();
+            }
+            return false;
+        }
+        return true;
+    }
 
+    // 길이 경고 알림
+    showLengthAlert() {
+        if (this.state.isShowingAlert) return;
+
+        this.state.isShowingAlert = true;
+        alert(`검색어를 ${this.MIN_SEARCH_LENGTH}글자 이상 입력해주세요.`);
+
+        setTimeout(() => {
+            this.state.isShowingAlert = false;
+            this.searchInput.focus();
+        }, 200);
+    }
 
     // 검색 결과 표시
     displaySearchResults(response) {
         if (!this.searchResults) return;
 
-        // API 응답 구조에 맞게 'popups' 필드 사용
-        if (!response || !response.popups || response.popups.length === 0) {
+        // 응답 구조 확인
+        const popups = response?.popups || [];
+        const totalElements = response?.totalElements || 0;
+
+        if (popups.length === 0) {
             this.showNoResults();
             return;
         }
 
         this.searchResults.innerHTML = `
-            <div class="search-results-title">'${this.escapeHtml(this.currentQuery)}' 검색 결과 (${response.totalElements}개)</div>
+            <div class="search-results-title">'${this.escapeHtml(this.state.currentQuery)}' 검색 결과 (${totalElements}개)</div>
             <div class="search-results-grid">
-                ${response.popups.map(popup => this.createSearchResultCard(popup)).join('')}
+                ${popups.map(popup => this.createSearchResultCard(popup)).join('')}
             </div>`;
         this.showSearchResults();
     }
@@ -430,7 +418,7 @@ class PopupSearchManager {
             <div class="no-results">
                 <div class="no-results-icon">🔍</div>
                 <h3>검색 결과가 없습니다</h3>
-                <p>'${this.escapeHtml(this.currentQuery)}'에 대한 검색 결과를 찾을 수 없습니다.</p>
+                <p>'${this.escapeHtml(this.state.currentQuery)}'에 대한 검색 결과를 찾을 수 없습니다.</p>
                 <p>다른 검색어로 다시 시도해보세요.</p>
             </div>`;
         this.showSearchResults();
@@ -448,12 +436,22 @@ class PopupSearchManager {
         this.showSearchResults();
     }
 
-    // 검색 결과 표시
+    // 자동완성 숨김
+    hideAutocomplete() {
+        if (this.relatedSearches) {
+            this.relatedSearches.classList.remove('show');
+            this.searchInput.closest('.search-input-wrapper').classList.remove('autocomplete-active');
+            this.searchInput.closest('.search-area').classList.remove('active');
+        }
+        this.autocompleteItems = [];
+        this.state.selectedIndex = -1;
+    }
+
+    // UI 표시/숨김 메서드들
     showSearchResults() {
         if (this.searchResults) this.searchResults.classList.add('show');
     }
 
-    // 검색 결과 숨김
     hideSearchResults() {
         if (this.searchResults) this.searchResults.classList.remove('show');
     }
@@ -482,6 +480,7 @@ class PopupSearchManager {
         }
     }
 
+    // HTML 이스케이프
     escapeHtml(text) {
         if (typeof text !== 'string') return '';
         const map = {

--- a/src/main/resources/static/js/popup-search.js
+++ b/src/main/resources/static/js/popup-search.js
@@ -400,13 +400,13 @@ class PopupSearchManager {
 
         return `
             <div class="popup-card" data-popup-id="${popupId}">
-                <div class="popup-image">
-                    <img src="${imgSrc}" alt="${safeTitle}" loading="lazy">
+                <div class="card-image-wrapper">
+                    <img src="${imgSrc}" alt="${safeTitle}" class="card-image" loading="lazy">
                 </div>
-                <div class="popup-info">
-                    <h3 class="popup-title">${safeTitle}</h3>
-                    <p class="popup-region">${safeRegion}</p>
-                    <p class="popup-period">${safePeriod}</p>
+                <div class="card-content">
+                    <h3 class="card-title">${safeTitle}</h3>
+                    <p class="card-info location">${safeRegion}</p>
+                    <p class="card-info">${safePeriod}</p>
                 </div>
             </div>`;
     }


### PR DESCRIPTION
## 📌 Summary
- resolve: #149 
- Related Jira: POP-148

## ✨ Description
<!-- 변경 사항 요약 -->
### 검색 탭에서 검색어 입력 시 자동완성 리스트가 뜰 수 있도록 구현했습니다. 

검색은 태그와, 팝업 제목으로 가능합니다.
자동완성 리스트는 최대 10개까지 보여집니다.

## 📸 Screenshot
<!-- UI 변화가 없다면 지워주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src="https://github.com/user-attachments/assets/c067e447-38b5-4e7a-bca8-67538eab3d52" width="500" />|

## 🗒️ Review Point
```
추가 수정 사항 생기면 공유해 주세요 :)
```

## ✅ CheckList
- [x] 자동완성 쿼리
- [x] 프론트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Autocomplete suggestions with keyboard navigation, caching, debounced input, click-to-select, and a loading indicator.
  - Autocomplete API endpoint and client-side method to fetch suggestions.

- Improvements
  - Redesigned search results into card-based layouts with refined responsiveness, spacing, and hover effects.
  - More predictable pagination via explicit page/size parameters.

- UX/Bug Fixes
  - Clearer empty/error states and safer rendering of result titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->