### PR TITLE
feat #POP-149: 데이터 보존 처리, 완료된 컨텐츠 숨김처리, 디자인 수정

### DIFF
--- a/src/main/java/com/snow/popin/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/snow/popin/domain/space/controller/SpaceController.java
@@ -140,7 +140,7 @@ public class SpaceController {
     @DeleteMapping("/{id}")
     public ResponseEntity<?> delete(@PathVariable Long id) {
         User me = userUtil.getCurrentUser();
-        spaceService.delete(me, id);
+        spaceService.deleteSpace(me, id);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/snow/popin/domain/space/repository/SpaceRepository.java
+++ b/src/main/java/com/snow/popin/domain/space/repository/SpaceRepository.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 public interface SpaceRepository extends JpaRepository<Space, Long>, JpaSpecificationExecutor<Space> {
 
     // 특정 사용자가 소유한 공간 목록 조회
-    List<Space> findByOwnerOrderByCreatedAtDesc(User owner);
+    List<Space> findByOwnerAndIsHiddenFalseOrderByCreatedAtDesc(User owner);
 
     // 특정 사용자 소유의 특정 공간 조회 (권한 체크용)
     Optional<Space> findByIdAndOwner(Long id, User owner);

--- a/src/main/java/com/snow/popin/domain/space/repository/SpaceRepository.java
+++ b/src/main/java/com/snow/popin/domain/space/repository/SpaceRepository.java
@@ -21,9 +21,6 @@ public interface SpaceRepository extends JpaRepository<Space, Long>, JpaSpecific
     // 특정 사용자 소유의 특정 공간 조회 (권한 체크용)
     Optional<Space> findByIdAndOwner(Long id, User owner);
 
-    // 공간 모두 조회
-    List<Space> findByIsPublicTrueOrderByCreatedAtDesc();
-
     List<Space> findByOwner(User owner);
 
     List<Space> findByIsPublicTrueAndIsHiddenFalseOrderByCreatedAtDesc();

--- a/src/main/java/com/snow/popin/domain/space/scheduler/SpaceScheduler.java
+++ b/src/main/java/com/snow/popin/domain/space/scheduler/SpaceScheduler.java
@@ -1,0 +1,38 @@
+package com.snow.popin.domain.space.scheduler;
+
+import com.snow.popin.domain.space.entity.Space;
+import com.snow.popin.domain.space.repository.SpaceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SpaceScheduler {
+
+    private final SpaceRepository spaceRepository;
+
+    // 매 시 정각 실행
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional
+    public void hideExpiredSpaces() {
+        LocalDate today = LocalDate.now();
+
+        List<Space> expiredSpaces = spaceRepository.findAll().stream()
+                .filter(space -> !space.getIsHidden()
+                        && space.getEndDate() != null
+                        && space.getEndDate().isBefore(today))
+                .collect(Collectors.toList());
+
+        expiredSpaces.forEach(Space::hide);
+
+        log.info("만료된 공간 {}개가 숨김 처리됨", expiredSpaces.size());
+    }
+}

--- a/src/main/java/com/snow/popin/domain/space/service/SpaceService.java
+++ b/src/main/java/com/snow/popin/domain/space/service/SpaceService.java
@@ -194,7 +194,7 @@ public class SpaceService {
     public List<SpaceListResponseDto> listMine(User owner) {
         log.debug("Fetching spaces for owner: {}", owner.getId());
 
-        return spaceRepository.findByOwnerOrderByCreatedAtDesc(owner)
+        return spaceRepository.findByOwnerAndIsHiddenFalseOrderByCreatedAtDesc(owner)
                 .stream()
                 .map(space -> SpaceListResponseDto.from(space, owner))
                 .collect(Collectors.toList());

--- a/src/main/java/com/snow/popin/domain/space/service/SpaceService.java
+++ b/src/main/java/com/snow/popin/domain/space/service/SpaceService.java
@@ -174,13 +174,13 @@ public class SpaceService {
      * @param owner 삭제 요청 사용자
      * @param id    공간 ID
      */
-    public void delete(User owner, Long id) {
+    public void deleteSpace(User owner, Long id) {
         log.info("Deleting space ID: {} by owner: {}", id, owner.getId());
 
         Space space = spaceRepository.findByIdAndOwner(id, owner)
                 .orElseThrow(() -> new IllegalArgumentException("공간이 없거나 삭제 권한이 없습니다."));
 
-        spaceRepository.delete(space);
+        space.hide();
         log.info("Space deleted successfully: {}", id);
     }
 

--- a/src/main/java/com/snow/popin/domain/spacereservation/entity/SpaceReservation.java
+++ b/src/main/java/com/snow/popin/domain/spacereservation/entity/SpaceReservation.java
@@ -54,6 +54,17 @@ public class SpaceReservation extends BaseEntity {
     @Column(nullable = false)
     private ReservationStatus status;
 
+    @Column(nullable = false)
+    private boolean isHidden = false;
+
+    public void hide() {
+        this.isHidden = true;
+    }
+
+    public void setHidden(boolean hidden) {
+        this.isHidden = hidden;
+    }
+
     // Status 관련 메서드
     public void accept() {
         if (this.status != ReservationStatus.PENDING) {

--- a/src/main/java/com/snow/popin/domain/spacereservation/repository/SpaceReservationRepository.java
+++ b/src/main/java/com/snow/popin/domain/spacereservation/repository/SpaceReservationRepository.java
@@ -17,32 +17,32 @@ import java.util.Optional;
 public interface SpaceReservationRepository extends JpaRepository<SpaceReservation, Long> {
 
     // 특정 사용자가 요청한 예약 목록 (HOST)
-    List<SpaceReservation> findByHostOrderByCreatedAtDesc(User host);
+    List<SpaceReservation> findByHostAndIsHiddenFalseOrderByCreatedAtDesc(User host);
 
     // 특정 공간 소유자에게 온 예약 목록 (PROVIDER)
-    @Query("SELECT sr FROM SpaceReservation sr WHERE sr.space.owner = :owner ORDER BY sr.createdAt DESC")
+    @Query("SELECT sr FROM SpaceReservation sr " +
+            "WHERE sr.space.owner = :owner AND sr.isHidden = false " +
+            "ORDER BY sr.createdAt DESC")
     List<SpaceReservation> findBySpaceOwnerOrderByCreatedAtDesc(@Param("owner") User owner);
 
     // 특정 사용자의 특정 예약 조회
-    Optional<SpaceReservation> findByIdAndHost(Long id, User host);
+    Optional<SpaceReservation> findByIdAndHostAndIsHiddenFalse(Long id, User host);
 
     // 특정 공간 소유자의 특정 예약 조회
-    @Query("SELECT sr FROM SpaceReservation sr WHERE sr.id = :id AND sr.space.owner = :owner")
+    @Query("SELECT sr FROM SpaceReservation sr WHERE sr.id = :id AND sr.space.owner = :owner AND sr.isHidden = false")
     Optional<SpaceReservation> findByIdAndSpaceOwner(@Param("id") Long id, @Param("owner") User owner);
 
     // 날짜 중복 체크용 - 특정 공간의 특정 기간에 승인된 예약이 있는지 확인
     @Query("SELECT COUNT(sr) FROM SpaceReservation sr WHERE sr.space = :space " +
-            "AND sr.status = 'ACCEPTED' " +
+            "AND sr.status = 'ACCEPTED' AND sr.isHidden = false " +
             "AND ((sr.startDate <= :endDate AND sr.endDate >= :startDate))")
     long countOverlappingReservations(@Param("space") Space space,
                                       @Param("startDate") LocalDate startDate,
                                       @Param("endDate") LocalDate endDate);
 
-    //이하 나중에 사용 할 수 있음
     // 특정 공간의 모든 예약 목록
-    List<SpaceReservation> findBySpaceOrderByStartDateDesc(Space space);
+    List<SpaceReservation> findBySpaceAndIsHiddenFalseOrderByStartDateDesc(Space space);
 
     // 특정 상태의 예약 목록
-    List<SpaceReservation> findByStatusOrderByCreatedAtDesc(ReservationStatus status);
-
+    List<SpaceReservation> findByStatusAndIsHiddenFalseOrderByCreatedAtDesc(ReservationStatus status);
 }

--- a/src/main/java/com/snow/popin/domain/spacereservation/service/SpaceReservationService.java
+++ b/src/main/java/com/snow/popin/domain/spacereservation/service/SpaceReservationService.java
@@ -157,6 +157,10 @@ public class SpaceReservationService {
 
         reservation.accept();
 
+        // 해당 공간 삭제(숨김)처리
+        Space space = reservation.getSpace();
+        space.hide();
+
         // 예약 신청자에게 알림 전송
         notificationService.createNotification(
                 reservation.getHost().getId(),

--- a/src/main/resources/static/css/mypage/host/host-popup-detail.css
+++ b/src/main/resources/static/css/mypage/host/host-popup-detail.css
@@ -11,7 +11,7 @@
 /* ===== 제목 스타일 (호스트 페이지와 통일) ===== */
 .block-title,
 .section-title {
-    background: #2563eb !important;
+    background: #4B5AE4 !important;
     border-radius: 12px !important;
     padding: 20px !important;
     margin-bottom: 24px !important;

--- a/src/main/resources/static/css/mypage/host/mpg-host.css
+++ b/src/main/resources/static/css/mypage/host/mpg-host.css
@@ -1,14 +1,12 @@
-/* mpg-host.css - 마이페이지 호스트 전체 스타일 (provider와 동일한 사용자 정보 디자인) */
-
 /* === 페이지 컨테이너 === */
 .mypage-host {
     padding: 0;
     background: #f9fafb;
 }
 
-/* === 제목 스타일 (블루 헤더) === */
+/* === 제목 스타일 === */
 .section-title {
-    background: #2563eb !important;
+    background: #4B5AE4 !important;
     border-radius: 12px !important;
     padding: 20px !important;
     margin: 20px 16px 24px 16px !important;
@@ -17,8 +15,8 @@
 
 .section-title h2 {
     color: white !important;
-    font-size: 18px !important;
-    font-weight: 600 !important;
+    font-size: 1.25rem !important;
+    font-weight: 700 !important;
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
     margin: 0 !important;
 }
@@ -30,21 +28,21 @@
 }
 
 .block-title {
-    background: #2563eb !important;
+    background: #4B5AE4 !important;
     border-radius: 12px !important;
     padding: 20px !important;
     margin-bottom: 24px !important;
     box-shadow: 0 4px 20px rgba(37, 99, 235, 0.3) !important;
     color: white !important;
-    font-size: 18px !important;
-    font-weight: 600 !important;
+    font-size: 1.25rem !important;
+    font-weight: 700 !important;
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
 }
 
 .card-list {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 16px;
 }
 
 /* === 사용자 정보 === */
@@ -52,22 +50,25 @@
     background: white;
     border-radius: 12px;
     padding: 20px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    border: 1px solid #f1f5f9;
 }
 
 .user-profile {
     background: white;
     border-radius: 12px;
     padding: 0;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    border: 1px solid #f1f5f9;
 }
 
+/* === 호스트용 프로필 행 (기존) === */
 .profile-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
     padding: 16px 20px;
-    border-bottom: 1px solid #f0f0f0;
+    border-bottom: 1px solid #f8fafc;
 }
 
 .profile-row:last-child {
@@ -76,16 +77,17 @@
 
 .profile-row .label {
     font-weight: 600;
-    color: #374151;
+    color: #333;
     min-width: 80px;
-    font-size: 14px;
+    font-size: 0.9rem;
 }
 
 .profile-row .value {
     flex: 1;
     margin: 0 12px;
-    color: #6b7280;
-    font-size: 14px;
+    color: #6a6a6a;
+    font-size: 0.9rem;
+    font-weight: 500;
 }
 
 .profile-row.readonly .value {
@@ -93,21 +95,56 @@
     font-style: italic;
 }
 
+/* === 마이페이지 정보 === */
+.mypage-info {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 20px;
+}
+
+.info-row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.info-label {
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: #333;
+}
+
+.info-value-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+}
+
+.info-value {
+    color: #6a6a6a;
+    flex: 1;
+}
+
 .edit-btn {
-    background: #3b82f6;
-    color: white;
-    border: none;
-    border-radius: 6px;
     padding: 8px 16px;
-    font-size: 12px;
-    font-weight: 500;
+    font-size: 14px;
+    font-weight: 600;
+    border: none;
+    background-color: #f3f4f6;
+    color: #4b5563;
+    border-radius: 20px;
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all 0.2s ease;
+    white-space: nowrap;
 }
 
 .edit-btn:hover {
-    background: #2563eb;
-    transform: translateY(-1px);
+    background-color: #4B5AE4;
+    color: white;
+    box-shadow: 0 2px 8px rgba(75, 90, 228, 0.3);
 }
 
 /* === 인라인 편집 === */
@@ -128,32 +165,30 @@
     gap: 8px;
 }
 
+/* 저장 / 취소 버튼 */
 .save-btn, .cancel-btn {
     padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 600;
     border: none;
-    border-radius: 8px;
-    font-size: 12px;
-    font-weight: 500;
+    border-radius: 20px;
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+}
+
+.save-btn:hover, .cancel-btn:hover, .edit-btn:hover {
+    box-shadow: 0 3px 3px rgb(90, 90, 90);
 }
 
 .save-btn {
-    background: #10b981;
+    background: #4b5ae4;
     color: white;
-}
-
-.save-btn:hover {
-    background: #059669;
 }
 
 .cancel-btn {
-    background: #6b7280;
+    background: #f44336;
     color: white;
-}
-
-.cancel-btn:hover {
-    background: #4b5563;
 }
 
 /* === 팝업 카드 === */
@@ -161,14 +196,17 @@
     background: white;
     border-radius: 12px;
     padding: 16px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    border: 1px solid #f1f5f9;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 16px;
+    transition: all 0.2s ease;
 }
 
 .popup-card:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+    transform: translateY(-1px);
 }
 
 .popup-card .thumb {
@@ -188,32 +226,50 @@
 
 .popup-card .info {
     flex: 1;
+    min-width: 0;
 }
 
 .popup-card .title {
-    font-size: 16px;
+    font-size: 0.9rem;
     font-weight: 600;
-    color: #374151;
+    color: #333;
     margin-bottom: 8px;
+    line-height: 1.3;
+    min-height: 1.3em;
+}
+
+.popup-card .meta {
+    font-size: 0.85rem;
+    color: #6a6a6a;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 
 .popup-card .right-actions {
     display: flex;
     flex-direction: column;
     gap: 8px;
+    align-self: flex-start;
 }
 
 .btn-detail, .btn-manage, .btn-stats {
-    background: #f8fafc;
+    background: #f3f4f6;
     border: 1px solid #e2e8f0;
     border-radius: 8px;
     padding: 8px 12px;
-    font-size: 12px;
+    font-size: 0.75rem;
     font-weight: 500;
-    color: #475569;
+    color: #4b5563;
     cursor: pointer;
     transition: all 0.2s;
     white-space: nowrap;
+}
+
+.btn-detail:hover, .btn-manage:hover, .btn-stats:hover {
+    background: #4B5AE4;
+    color: white;
+    border-color: #4B5AE4;
 }
 
 /* === 예약 카드 === */
@@ -221,7 +277,14 @@
     background: white;
     border-radius: 12px;
     padding: 16px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    border: 1px solid #f1f5f9;
+    transition: all 0.2s ease;
+    position: relative;
+}
+
+.rent-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
 }
 
 .rent-card .left {
@@ -237,6 +300,27 @@
     overflow: hidden;
     background: #f3f4f6;
     flex-shrink: 0;
+}
+
+.rent-card .address {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 8px;
+    line-height: 1.3;
+    min-height: 1.3em;
+}
+
+.rent-card .desc {
+    font-size: 0.85rem;
+    color: #6a6a6a;
+    margin-bottom: 4px;
+}
+
+.rent-card .dates {
+    font-size: 0.85rem;
+    color: #6a6a6a;
+    margin-bottom: 8px;
 }
 
 .rent-card .right-actions {
@@ -260,34 +344,28 @@
 
 /* 공통 버튼 */
 .btn-map, .btn-detail, .btn-cancel, .btn-chat {
-    background: #f8fafc;
+    background: #f3f4f6;
     border: 1px solid #e2e8f0;
     border-radius: 8px;
     padding: 8px 12px;
-    font-size: 12px;
+    font-size: 0.75rem;
     font-weight: 500;
-    color: #475569;
+    color: #4b5563;
     cursor: pointer;
     transition: all 0.2s;
 }
 
-.btn-map:hover, .btn-detail:hover {
-    background: #f1f5f9;
-}
-
-.btn-cancel {
-    background: #fef2f2;
-    border-color: #fecaca;
-    color: #dc2626;
-}
-
-.btn-cancel:hover {
-    background: #fee2e2;
-    border-color: #f87171;
+.btn-map:hover, .btn-detail:hover, .btn-cancel:hover {
+    background: #4B5AE4;
+    color: white;
+    border-color: #4B5AE4;
 }
 
 /* 채팅 버튼 - 아이콘 전용 */
 .btn-chat {
+    position: absolute; /* 추가: 절대 위치 */
+    top: 16px;         /* 추가: 상단에서 16px */
+    right: 16px;       /* 추가: 우측에서 16px */
     width: 36px;
     height: 36px;
     border-radius: 50%;
@@ -298,35 +376,90 @@
     background: #3b82f6;
     border: none;
     color: white;
+    transition: all 0.2s ease;
+}
+
+.btn-chat:hover {
+    background: #2563eb;
+    transform: scale(1.05);
 }
 
 .btn-chat::before {
     content: "";
     width: 18px;
     height: 18px;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='white'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4-.8L3 20l1.2-3.6A7.96 7.96 0 013 12c0-4.418 4.03-8 9-8s9 3.582 9 8z'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='white'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4-.8L3 20l1.2-3.6A7.96 7.96 0 713 12c0-4.418 4.03-8 9-8s9 3.582 9 8z'/%3E%3C/svg%3E");
     background-size: cover;
+}
+
+/* === 상태 배지 === */
+.status-badge {
+    display: inline-block;
+    padding: 4px 8px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    border-radius: 12px;
+    text-align: center;
+    background: #B6BCF7;
+    color: #374151;
+}
+
+.status-badge.planned {
+    background: #B6BCF7;
+    color: #374151;
+}
+
+.status-badge.ongoing {
+    background: #B6BCF7;
+    color: #374151;
+}
+
+.status-badge.finished {
+    background: #B6BCF7;
+    color: #374151;
+}
+
+.status-badge.cancelled {
+    background: #B6BCF7;
+    color: #374151;
+}
+
+.status-badge.pending {
+    background: #B6BCF7;
+    color: #374151;
+}
+
+.status-badge.accepted {
+    background: #B6BCF7;
+    color: #374151;
+}
+
+.status-badge.rejected {
+    background: #B6BCF7;
+    color: #374151;
 }
 
 /* === 등록 버튼 === */
 .register-btn {
     width: auto;
-    padding: 10px 20px;
-    font-size: 14px;
+    padding: 12px 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
     margin-left: auto;
     display: block;
-    background: #2563eb;
+    background: #4B5AE4;
     color: white;
     border: none;
     border-radius: 12px;
-    font-weight: 600;
     cursor: pointer;
     margin-bottom: 20px;
+    transition: all 0.2s ease;
 }
 
 .register-btn:hover {
-    background: #1d4ed8;
-    box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3);
+    background: #3a46c4;
+    box-shadow: 0 4px 12px rgba(75, 90, 228, 0.3);
+    transform: translateY(-1px);
 }
 
 /* === 빈 상태 === */
@@ -334,7 +467,7 @@
     text-align: center;
     padding: 40px 20px;
     color: #6b7280;
-    font-size: 14px;
+    font-size: 0.9rem;
     background: #f9fafb;
     border-radius: 12px;
     border: 2px dashed #d1d5db;
@@ -356,5 +489,9 @@
 
     .rent-card .left {
         width: 100%;
+    }
+
+    .action-left, .action-right {
+        flex-wrap: wrap;
     }
 }

--- a/src/main/resources/static/css/mypage/host/popup-edit.css
+++ b/src/main/resources/static/css/mypage/host/popup-edit.css
@@ -23,7 +23,7 @@
 .section-title,
 h3.block-title,
 h2.block-title {
-    background: #2563eb !important;
+    background: #4B5AE4 !important;
     border-radius: 12px !important;
     padding: 20px !important;
     margin-bottom: 24px !important;

--- a/src/main/resources/static/css/mypage/host/popup-register.css
+++ b/src/main/resources/static/css/mypage/host/popup-register.css
@@ -25,7 +25,7 @@
 
 /* ===== 섹션 제목 (호스트 페이지와 통일) ===== */
 .section-title {
-    background: #2563eb !important;
+    background: #4B5AE4 !important;
     border-radius: 12px !important;
     padding: 20px !important;
     margin-bottom: 24px !important;

--- a/src/main/resources/static/css/mypage/host/popup-stats.css
+++ b/src/main/resources/static/css/mypage/host/popup-stats.css
@@ -10,7 +10,7 @@
 
 /* 블록 타이틀 */
 .block-title {
-    background: #2563eb !important;
+    background: #4B5AE4 !important;
     border-radius: 12px !important;
     padding: 20px !important;
     margin-bottom: 24px !important;

--- a/src/main/resources/static/css/mypage/host/reservation-manage.css
+++ b/src/main/resources/static/css/mypage/host/reservation-manage.css
@@ -8,7 +8,7 @@
     margin-bottom: 24px;
 }
 
-/* ===== 블록 제목 (호스트 페이지와 통일) ===== */
+/* ===== 블록 제목  ===== */
 .block-title {
     background: #2563eb !important;
     border-radius: 12px !important;
@@ -27,11 +27,11 @@
     padding: 16px 0;
 }
 
-/* ===== 팝업 헤더 (호스트 페이지와 통일) ===== */
+/* ===== 팝업 헤더  ===== */
 .popup-header {
     display: flex;
     align-items: center;
-    background: #2563eb !important;
+    background: #4B5AE4 !important;
     padding: 20px;
     border-radius: 16px;
     color: white;
@@ -116,6 +116,7 @@
 .tab-content {
     display: none;
     animation: fadeIn 0.3s ease;
+    padding: 20px;
 }
 
 .tab-content.active {
@@ -467,7 +468,7 @@
 }
 
 .save-settings-btn {
-    background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%) !important;
+    background: #14229c !important;
     color: white;
     border: none;
     border-radius: 12px;

--- a/src/main/resources/static/css/mypage/provider/mpg-provider.css
+++ b/src/main/resources/static/css/mypage/provider/mpg-provider.css
@@ -8,7 +8,7 @@
 
 /* === 제목 스타일 (블루 헤더) === */
 .section-title {
-    background: #2563eb !important;
+    background: #4B5AE4  !important;
     border-radius: 12px !important;
     padding: 20px !important;
     margin: 20px 16px 24px 16px !important;
@@ -30,7 +30,7 @@
 }
 
 .block-title {
-    background: #2563eb !important;
+    background: #4B5AE4  !important;
     border-radius: 12px !important;
     padding: 20px !important;
     margin-bottom: 24px !important;
@@ -55,6 +55,7 @@
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
+/* 호스트용 프로필 행 (기존) */
 .profile-row {
     display: flex;
     align-items: center;
@@ -84,19 +85,57 @@
     font-style: italic;
 }
 
+/* === 일반 사용자용 마이페이지 정보 === */
+.mypage-info {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 20px;
+}
+
+.info-row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.info-label {
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: #333;
+}
+
+.info-value-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+}
+
+.info-value {
+    color: #6a6a6a;
+    flex: 1;
+    font-size: 0.9rem;
+}
+
 .edit-btn {
-    background: #3b82f6;
-    color: white;
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 600;
     border: none;
-    border-radius: 6px;
-    padding: 6px 12px;
-    font-size: 12px;
+    background-color: #f3f4f6;
+    color: #4b5563;
+    border-radius: 20px;
     cursor: pointer;
-    transition: background-color 0.2s;
+    transition: all 0.2s ease;
+    white-space: nowrap;
 }
 
 .edit-btn:hover {
-    background: #2563eb;
+    background-color: #4B5AE4;
+    color: white;
+    box-shadow: 0 2px 8px rgba(75, 90, 228, 0.3);
 }
 
 /* 인라인 편집 스타일 */
@@ -107,6 +146,16 @@
     border: 1px solid #d1d5db;
     border-radius: 4px;
     font-size: 14px;
+}
+
+/* 일반 사용자용 인라인 편집 */
+.info-value-row .inline-edit {
+    flex: 1;
+    padding: 6px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-size: 14px;
+    margin: 0;
 }
 
 .button-group {
@@ -124,8 +173,8 @@
 }
 
 .save-btn {
-    background: #10b981;
-    color: white;
+    background: #4B5AE4;
+    color: #4B5AE4;
 }
 
 .save-btn:hover {
@@ -179,18 +228,22 @@
 }
 
 .edit-btn {
-    background: #3b82f6;
-    color: white;
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 600;
     border: none;
-    border-radius: 6px;
-    padding: 6px 12px;
-    font-size: 12px;
+    background-color: #f3f4f6;
+    color: #4b5563;
+    border-radius: 20px;
     cursor: pointer;
-    transition: background-color 0.2s;
+    transition: all 0.2s ease;
+    white-space: nowrap;
 }
 
 .edit-btn:hover {
-    background: #2563eb;
+    background-color: #4B5AE4;
+    color: white;
+    box-shadow: 0 2px 8px rgba(75, 90, 228, 0.3);
 }
 
 /* 인라인 편집 스타일 */
@@ -208,31 +261,27 @@
     gap: 6px;
 }
 
+/* 저장 / 취소 버튼 */
 .save-btn, .cancel-btn {
-    padding: 6px 10px;
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 600;
     border: none;
-    border-radius: 4px;
-    font-size: 12px;
+    border-radius: 20px;
     cursor: pointer;
-    transition: background-color 0.2s;
+    transition: all 0.2s ease;
+    white-space: nowrap;
 }
-
+.save-btn:hover, .cancel-btn:hover, .edit-btn:hover {
+    box-shadow: 0 3px 3px rgb(90, 90, 90);
+}
 .save-btn {
-    background: #10b981;
+    background: #4b5ae4;
     color: white;
 }
-
-.save-btn:hover {
-    background: #059669;
-}
-
 .cancel-btn {
-    background: #6b7280;
+    background: #f44336;
     color: white;
-}
-
-.cancel-btn:hover {
-    background: #4b5563;
 }
 
 /* === 통계 그리드 === */
@@ -506,26 +555,36 @@
     color: #6b7280;
 }
 
-/* 채팅 플로팅 버튼 */
+/* === 채팅 버튼 (host 스타일과 동일) === */
 .chat-floating {
     position: absolute;
     top: 16px;
     right: 16px;
-    width: 40px;
-    height: 40px;
-    border: none;
+    width: 36px;
+    height: 36px;
     border-radius: 50%;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background: #3b82f6;
+    border: none;
     color: white;
-    font-size: 16px;
     cursor: pointer;
-    box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
-    transition: all 0.2s;
+    transition: all 0.2s ease;
 }
 
 .chat-floating:hover {
     background: #2563eb;
-    transform: scale(1.1);
+    transform: scale(1.05);
+}
+
+.chat-floating::before {
+    content: "";
+    width: 18px;
+    height: 18px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='white'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4-.8L3 20l1.2-3.6A7.96 7.96 0 013 12c0-4.418 4.03-8 9-8s9 3.582 9 8z'/%3E%3C/svg%3E");
+    background-size: cover;
 }
 
 /* 액션바 */
@@ -545,7 +604,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 6px;
 }
 
 .btn-accept {

--- a/src/main/resources/static/css/space/space-detail.css
+++ b/src/main/resources/static/css/space/space-detail.css
@@ -47,7 +47,7 @@
 
 /* ===== 페이지 제목 (호스트 페이지와 통일) ===== */
 .page-title {
-    background: #2563eb !important;
+    background: #4B5AE4 !important;
     border-radius: 12px;
     padding: 20px;
     margin-bottom: 24px;

--- a/src/main/resources/static/css/space/space-list.css
+++ b/src/main/resources/static/css/space/space-list.css
@@ -23,17 +23,15 @@
     margin: 0 auto;
 }
 
-/* ===== 페이지 헤더 (호스트 페이지와 통일) ===== */
 .page-header {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 24px;
-    padding: 16px 0;
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-start;
 }
 
 .page-title {
-    background: #2563eb !important;
+    background: #4B5AE4 !important;
     border-radius: 12px !important;
     padding: 20px !important;
     margin: 0 !important;
@@ -43,12 +41,13 @@
     font-weight: 600 !important;
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
     flex: 1;
-    text-align: center;
-    margin-right: 16px !important;
+    text-align: left;
+    margin-right: 0px !important;
+    width: 100%;
 }
 
 .register-btn {
-    background: #1e40af !important;
+    background: #14229c !important;
     color: white;
     text-decoration: none;
     padding: 12px 20px;
@@ -58,6 +57,8 @@
     transition: all 0.2s ease;
     box-shadow: 0 2px 8px rgba(30, 64, 175, 0.3) !important;
     flex-shrink: 0;
+    align-self: flex-end;
+    margin-bottom: 16px;
 }
 
 .register-btn:hover {
@@ -105,7 +106,7 @@
 
 .search-btn {
     padding: 12px 24px;
-    background: #4B5AE4 !important;
+    background: #14229c !important;
     color: white;
     border: none;
     border-radius: 12px;
@@ -194,7 +195,7 @@
 }
 
 .apply-btn {
-    background: #10b981;
+    background: #14229c;
     color: white;
 }
 
@@ -304,65 +305,76 @@
     gap: 16px;
 }
 
-/* ===== 공간 카드 ===== */
+/* ===== 공간 카드  ===== */
 .space-card {
     background: white;
     border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
     overflow: hidden;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    border: 1px solid #e5e7eb;
-    transition: transform 0.2s, box-shadow 0.2s;
+    transition: all 0.2s ease;
 }
 
 .space-card:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(0,0,0,0.12);
 }
 
-.space-header {
-    display: flex;
-    gap: 16px;
-    padding: 20px;
-}
-
-.space-header > div:first-child {
-    flex: 1;
-}
-
+/*  제목  */
 .space-title {
     font-size: 18px;
-    font-weight: 600;
-    color: #111827;
-    margin: 0 0 12px 0;
-    line-height: 1.3;
+    font-weight: 700;
+    color: black;
+    padding: 16px;
+    margin: 0;
+    border-bottom: 1px solid #f0f0f0;
 }
 
+/*  본문: 이미지(왼쪽) + 정보들(오른쪽) */
+.space-body {
+    display: flex;
+    padding: 16px;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+/* 왼쪽 이미지 */
+.space-body .thumb {
+    flex: 0 0 140px;
+    width: 140px;
+    height: 140px;
+    object-fit: cover;
+    border-radius: 8px;
+}
+
+/* 오른쪽 정보들 */
 .space-details {
+    flex: 1;
     display: flex;
     flex-direction: column;
     gap: 8px;
-    margin-bottom: 16px;
+    margin-bottom: 0;
 }
 
 .space-details > div {
     font-size: 14px;
-    color: #6b7280;
-    display: flex;
-    align-items: center;
-    padding: 8px 12px;
-    background: #f9fafb;
-    border-radius: 6px;
-    border: 1px solid #f3f4f6;
+    color: #555;
+    padding: 0;
+    margin: 0;
+    background: none;
+    border: none;
 }
 
+/* 등록자 강조 */
 .space-details > div:first-child {
-    color: #111827;
-    font-weight: 500;
     background: #dbeafe !important;
-    border-color: rgba(37, 99, 235, 0.2) !important;
+    color: #111827 !important;
+    font-weight: 500 !important;
+    padding: 4px 8px !important;
+    border-radius: 4px !important;
+    width: fit-content;
 }
 
-/* ===== 인라인 액션 (호스트 페이지와 통일) ===== */
+/* 액션 링크들 */
 .actions-inline {
     display: flex;
     gap: 12px;
@@ -370,15 +382,16 @@
 }
 
 .actions-inline .link {
-    background: none;
-    border: none;
     color: #2563eb !important;
-    font-size: 13px;
-    font-weight: 500;
-    cursor: pointer;
-    padding: 4px 0;
+    font-size: 13px !important;
+    font-weight: 500 !important;
+    text-decoration: none;
     border-bottom: 1px solid transparent;
     transition: all 0.2s ease;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
 }
 
 .actions-inline .link:hover {
@@ -386,33 +399,16 @@
     border-bottom-color: #1e40af !important;
 }
 
-/* ===== 썸네일 ===== */
-.thumb {
-    width: 100px;
-    height: 80px;
-    object-fit: cover;
-    object-position: center;
-    border-radius: 8px;
-    flex-shrink: 0;
-    background: #f9fafb !important;
-    border: 1px solid #e5e7eb;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.thumb[src=""] {
-    background: #f9fafb !important;
-}
-
-/* ===== 카드 하단 메타 정보 ===== */
+/* 3. 등록일 (하단) */
 .space-meta {
+    border-top: 1px solid #f0f0f0;
+    padding: 12px 16px;
+    font-size: 13px;
+    color: #666;
+    background: #fafbfc;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 16px 20px;
-    border-top: 1px solid #f3f4f6;
-    background: #fafbfc;
 }
 
 .space-meta > span {
@@ -507,6 +503,21 @@
         gap: 8px;
         text-align: center;
     }
+
+    /* 모바일에서 카드 레이아웃 조정 */
+    .space-body {
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .space-body .thumb {
+        width: 100%;
+        height: 160px;
+    }
+
+    .space-details {
+        gap: 8px;
+    }
 }
 
 @media (max-width: 480px) {
@@ -532,35 +543,35 @@
         padding: 16px !important;
     }
 
-    .space-header {
+    .space-title {
+        font-size: 16px;
+        padding: 12px;
+    }
+
+    .space-body {
         flex-direction: column;
+        padding: 12px;
         gap: 12px;
-        padding: 16px;
     }
 
-    .thumb {
+    .space-body .thumb {
         width: 100%;
-        height: 120px;
-    }
-
-    .space-details {
-        gap: 6px;
+        height: 140px;
     }
 
     .space-details > div {
-        padding: 6px 10px;
         font-size: 13px;
     }
 
-    .actions-inline {
-        justify-content: space-between;
+    .space-details > div:first-child {
+        padding: 6px 10px !important;
     }
 
     .space-meta {
         flex-direction: column;
         gap: 12px;
         align-items: stretch;
-        padding: 12px 16px;
+        padding: 12px;
     }
 
     .space-actions {

--- a/src/main/resources/static/css/space/space-list.css
+++ b/src/main/resources/static/css/space/space-list.css
@@ -443,13 +443,14 @@
 }
 
 .action-btn.delete {
-    background: #fee2e2;
-    color: #991b1b;
-    border: 1px solid #fecaca;
+    background: #f3f4f6;
+    color: #6b7280;
+    border: 1px solid #d1d5db;
 }
 
 .action-btn.delete:hover {
-    background: #fecaca;
+    background: #e5e7eb;
+    color: #374151;
     transform: translateY(-1px);
 }
 

--- a/src/main/resources/static/css/space/space-register.css
+++ b/src/main/resources/static/css/space/space-register.css
@@ -27,7 +27,7 @@
 .section-title,
 h3.block-title,
 h2.block-title {
-    background: #2563eb !important;
+    background: #4B5AE4 !important;
     border-radius: 12px !important;
     padding: 20px !important;
     margin-bottom: 24px !important;

--- a/src/main/resources/static/js/api.js
+++ b/src/main/resources/static/js/api.js
@@ -335,7 +335,7 @@ apiService.rejectReservation = async function(reservationId) {
     return await this.put(`/space-reservations/${encodeURIComponent(reservationId)}/reject`, {});
 };
 
-// 예약 삭제 (거절된 예약만)
+// 예약 삭제
 apiService.deleteReservation = async function(reservationId) {
     return await this.delete(`/space-reservations/${encodeURIComponent(reservationId)}/delete`);
 };

--- a/src/main/resources/static/js/layout.js
+++ b/src/main/resources/static/js/layout.js
@@ -359,8 +359,7 @@ function createFooterByRole() {
         navItems += `
         <a href="#" class="footer-item" data-page="spaceList">
             <svg class="footer-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path>
-                <circle cx="12" cy="10" r="3"></circle>
+                <path d="M3 9.75L12 4l9 5.75V20a1 1 0 01-1 1h-5v-6H9v6H4a1 1 0 01-1-1V9.75z"></path>
             </svg>
             <span class="footer-text">공간대여</span>
         </a>`;
@@ -381,6 +380,7 @@ function createFooterByRole() {
         </footer>
     `;
 }
+
 
 // 현재 사용자 ROLE 반환
 async function getUserRole() {

--- a/src/main/resources/static/js/mypage/host/mpg-host.js
+++ b/src/main/resources/static/js/mypage/host/mpg-host.js
@@ -2,7 +2,7 @@ function translateStatus(status) {
     switch (status) {
         case 'PLANNED': return '준비 중';
         case 'ONGOING': return '진행 중';
-        case 'FINISHED': return '종료됨';
+        case 'ENDED': return '종료됨';
         case 'CANCELLED': return '취소됨';
         case 'PENDING': return '예약 대기 중';
         case 'ACCEPTED': return '승인됨';

--- a/src/main/resources/static/js/mypage/host/popup-edit.js
+++ b/src/main/resources/static/js/mypage/host/popup-edit.js
@@ -1,4 +1,8 @@
 document.addEventListener('DOMContentLoaded', async () => {
+
+    await loadComponents();
+    initializeLayout();
+
     const pathParts = window.location.pathname.split("/");
     const popupId = pathParts[pathParts.indexOf("popup") + 1];
 
@@ -11,7 +15,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const form = document.getElementById('popup-edit-form');
     const selectedTags = new Set();
 
-    // ✅ 태그 버튼 토글
+    //  태그 버튼 토글
     document.querySelectorAll(".tag-btn").forEach(btn => {
         btn.addEventListener("click", () => {
             const tagId = parseInt(btn.dataset.id, 10);

--- a/src/main/resources/static/js/mypage/provider/mpg-provider.js
+++ b/src/main/resources/static/js/mypage/provider/mpg-provider.js
@@ -286,7 +286,7 @@ class ProviderManager {
             btnDeleteTop.innerHTML = '×';
             btnDeleteTop.addEventListener('click', (e) => {
                 e.stopPropagation();
-                this.removeReservationCard(card);
+                this.removeReservationCard(card, reservation.id);
             });
             header.appendChild(btnDeleteTop);
         }
@@ -505,15 +505,25 @@ class ProviderManager {
         }
     }
 
-    removeReservationCard(cardElement) {
-        if (!confirm('이 예약을 화면에서 지우시겠습니까?')) return;
-        cardElement.remove();
+    async removeReservationCard(cardElement, reservationId) {
+        if (!confirm('이 예약을 목록에서 숨기시겠습니까?')) return;
 
-        const remainingCards = this.elements.reservationList.querySelectorAll('.reservation-card');
-        if (remainingCards.length === 0) {
-            this.elements.reservationList.innerHTML = '<div class="empty" data-empty>아직 받은 예약 요청이 없습니다.</div>';
+        try {
+            await apiService.deleteReservation(reservationId);
+            cardElement.remove();
+
+            const remainingCards = this.elements.reservationList.querySelectorAll('.reservation-card');
+            if (remainingCards.length === 0) {
+                this.elements.reservationList.innerHTML = '<div class="empty" data-empty>아직 받은 예약 요청이 없습니다.</div>';
+            }
+
+            alert('예약이 숨김 처리되었습니다.');
+        } catch (err) {
+            console.error('예약 숨김 처리 실패:', err);
+            alert('예약 숨김 처리에 실패했습니다.');
         }
     }
+
 
     getStatusText(status) {
         const statusMap = {

--- a/src/main/resources/static/js/mypage/provider/mpg-provider.js
+++ b/src/main/resources/static/js/mypage/provider/mpg-provider.js
@@ -350,7 +350,7 @@ class ProviderManager {
         if (reservation.status !== 'REJECTED' && reservation.status !== 'CANCELLED') {
             const btnChat = document.createElement('button');
             btnChat.className = 'chat-floating';
-            btnChat.innerHTML = '💬';
+            btnChat.innerHTML = '';
             btnChat.addEventListener('click', () => this.openChat(reservation.id));
             body.appendChild(btnChat);
         }
@@ -365,14 +365,14 @@ class ProviderManager {
 
             const btnAccept = document.createElement('button');
             btnAccept.className = 'action-btn btn-accept';
-            btnAccept.innerHTML = '<span>✓</span><span>수락</span>';
+            btnAccept.innerHTML = '<span>수락</span>';
             btnAccept.addEventListener('click', () => {
                 this.handleReservationAction('accept', reservation.id, reservation.popupTitle);
             });
 
             const btnReject = document.createElement('button');
             btnReject.className = 'action-btn btn-reject';
-            btnReject.innerHTML = '<span>✗</span><span>거절</span>';
+            btnReject.innerHTML = '<span>거절</span>';
             btnReject.addEventListener('click', () => {
                 this.handleReservationAction('reject', reservation.id, reservation.popupTitle);
             });

--- a/src/main/resources/static/js/space/space-list.js
+++ b/src/main/resources/static/js/space/space-list.js
@@ -167,37 +167,36 @@ class SpaceListManager {
         card.className = 'space-card';
 
         const imageUrl = this.getThumbUrl(space);
-        const imageHtml = `<img class="thumb" src="${imageUrl}" alt="썸네일">`;
 
         card.innerHTML = `
-      <div class="space-header">
-        <div>
-          <h4 class="space-title">${space.title || '(제목 없음)'}</h4>
-          <div class="space-details">
-            <div>등록자: ${space.ownerName || '-'}</div>
-            <div>임대료: ${this.formatRentalFee(space.rentalFee)}</div>
-            <div>주소: ${space.address || '-'}</div>
-            <div>면적: ${space.areaSize || '-'} m²</div>
-            <div class="actions-inline">
-              <button class="link" data-act="detail" data-id="${id}">상세정보</button>
-              <button class="link" data-act="inquire" data-id="${id}">문의하기</button>
-              <button class="link" data-act="report"  data-id="${id}">신고</button>
-            </div>
+      <div class="space-title">${space.title || '(제목 없음)'}</div>
+      
+      <div class="space-body">
+        <img class="thumb" src="${imageUrl}" alt="썸네일">
+        <div class="space-details">
+          <div>등록자: ${space.ownerName || '-'}</div>
+          <div>임대료: ${this.formatRentalFee(space.rentalFee)}</div>
+          <div>주소: ${space.address || '-'}</div>
+          <div>면적: ${space.areaSize || '-'} m²</div>
+          <div class="actions-inline">
+            <button class="link" data-act="detail" data-id="${id}">상세정보</button>
+            <button class="link" data-act="report" data-id="${id}">신고</button>
           </div>
         </div>
-        ${imageHtml}
       </div>
+      
       <div class="space-meta">
         <span>등록일: ${this.formatDate(space.createdAt)}</span>
         <div class="space-actions">
           ${space.mine ? `
-            <button class="action-btn edit"   data-act="edit"   data-id="${id}">수정</button>
+            <button class="action-btn edit" data-act="edit" data-id="${id}">수정</button>
             <button class="action-btn delete" data-act="delete" data-id="${id}">삭제</button>
           ` : ''}
         </div>
       </div>
     `;
 
+        // 이미지 에러 처리
         const imgEl = card.querySelector('.thumb');
         if (imgEl) {
             imgEl.onerror = function () {
@@ -206,6 +205,7 @@ class SpaceListManager {
             };
         }
 
+        // 이벤트 처리
         card.addEventListener('click', (e) => {
             const btn = e.target.closest('[data-act]');
             if (!btn) return;
@@ -230,7 +230,6 @@ class SpaceListManager {
                     this.reportSpace(targetId);
                     break;
             }
-
         });
 
         return card;

--- a/src/main/resources/static/templates/pages/mypage/host/mpg-host.html
+++ b/src/main/resources/static/templates/pages/mypage/host/mpg-host.html
@@ -24,29 +24,41 @@
         <!-- 마이페이지 -->
         <section class="block user-info">
             <h3 class="block-title">마이페이지 - 팝업 주최자</h3>
-            <div class="card user-profile">
-                <div class="profile-row readonly">
-                    <span class="label">계정명</span>
-                    <span id="user-email" class="value"></span>
-                </div>
-                <div class="profile-row">
-                    <span class="label">이름</span>
-                    <span id="user-name" class="value"></span>
-                    <button class="edit-btn">수정</button>
-                </div>
-                <div class="profile-row">
-                    <span class="label">닉네임</span>
-                    <span id="user-nickname" class="value"></span>
-                    <button class="edit-btn">수정</button>
-                </div>
-                <div class="profile-row">
-                    <span class="label">연락처</span>
-                    <span id="user-phone" class="value"></span>
-                    <button class="edit-btn">수정</button>
-                </div>
-                <div class="profile-row readonly">
-                    <span class="label">브랜드명</span>
-                    <span id="user-brand" class="value"></span>
+            <div class="card">
+                <div class="mypage-info">
+                    <div class="info-row">
+                        <div class="info-label">아이디</div>
+                        <div class="info-value-row">
+                            <span id="user-email" class="info-value"></span>
+                        </div>
+                    </div>
+                    <div class="info-row">
+                        <div class="info-label">이름</div>
+                        <div class="info-value-row">
+                            <span id="user-name" class="info-value"></span>
+                            <button class="edit-btn">수정</button>
+                        </div>
+                    </div>
+                    <div class="info-row">
+                        <div class="info-label">닉네임</div>
+                        <div class="info-value-row">
+                            <span id="user-nickname" class="info-value"></span>
+                            <button class="edit-btn">수정</button>
+                        </div>
+                    </div>
+                    <div class="info-row">
+                        <div class="info-label">연락처</div>
+                        <div class="info-value-row">
+                            <span id="user-phone" class="info-value"></span>
+                            <button class="edit-btn">수정</button>
+                        </div>
+                    </div>
+                    <div class="info-row">
+                        <div class="info-label">브랜드명</div>
+                        <div class="info-value-row">
+                            <span id="user-brand" class="info-value"></span>
+                        </div>
+                    </div>
                 </div>
             </div>
         </section>

--- a/src/main/resources/static/templates/pages/mypage/provider/mpg-provider.html
+++ b/src/main/resources/static/templates/pages/mypage/provider/mpg-provider.html
@@ -24,29 +24,38 @@
       </div>
       <br>
 
-      <!-- 사용자 정보 섹션 추가 -->
+      <!-- 사용자 정보 섹션 -->
       <section class="block user-info">
-        <div class="card user-profile">
-          <div class="profile-row readonly">
-            <span class="label">계정명</span>
-            <span id="user-email" class="value">-</span>
+        <div class="card">
+          <div class="mypage-info">
+            <div class="info-row">
+              <div class="info-label">아이디</div>
+              <div class="info-value-row">
+                <span id="user-email" class="info-value">-</span>
+              </div>
+            </div>
+            <div class="info-row">
+              <div class="info-label">이름</div>
+              <div class="info-value-row">
+                <span id="user-name" class="info-value">-</span>
+                <button class="edit-btn">수정</button>
+              </div>
+            </div>
+            <div class="info-row">
+              <div class="info-label">닉네임</div>
+              <div class="info-value-row">
+                <span id="user-nickname" class="info-value">-</span>
+                <button class="edit-btn">수정</button>
+              </div>
+            </div>
+            <div class="info-row">
+              <div class="info-label">연락처</div>
+              <div class="info-value-row">
+                <span id="user-phone" class="info-value">-</span>
+                <button class="edit-btn">수정</button>
+              </div>
+            </div>
           </div>
-          <div class="profile-row">
-            <span class="label">이름</span>
-            <span id="user-name" class="value">-</span>
-            <button class="edit-btn">수정</button>
-          </div>
-          <div class="profile-row">
-            <span class="label">닉네임</span>
-            <span id="user-nickname" class="value">-</span>
-            <button class="edit-btn">수정</button>
-          </div>
-          <div class="profile-row">
-            <span class="label">연락처</span>
-            <span id="user-phone" class="value">-</span>
-            <button class="edit-btn">수정</button>
-          </div>
-
         </div>
       </section>
 


### PR DESCRIPTION
## 📌 Summary
- resolve: #152 
- Related Jira: POP-149

## ✨ Description
<!-- 변경 사항 요약 -->
- 공간 등록, 혹은 예약 등에서 삭제 혹은 취소 등의 동작으로 하드삭제로 되어있던 것들을 소프트 삭제로 변경 (IsHidden 필드 추가)
- 디자인 수정
- 푸터 아이콘 변경

## 📸 Screenshot
<!-- UI 변화가 없다면 지워주세요 -->
|기능|스크린샷|
|:--:|:--:|
|색상 통일|<img src="https://github.com/user-attachments/assets/a9c52d15-1c2c-4a02-b9b8-2364ca18134a" width="500" />|
|푸터 아이콘 변경|<img src="https://github.com/user-attachments/assets/e63a768e-9f60-4a02-81c4-15c4bbe13aa0" width="500" />|
|공간 목록 변경|<img src="https://github.com/user-attachments/assets/4ab31693-2493-4466-82e4-2dc0ad505d7b" width="500" />|
|기타|<img src="https://github.com/user-attachments/assets/e031a83f-67c0-46ab-b9c4-c59e6ed8fe49" width="500" />|


## 🗒️ Review Point
```
- 디자인 색상 통일
- 삭제 및 취소한 컨텐츠 카드들이 더이상 등장하지 않음
- 기타 이미지의 상태에 따라 나타나는 색상은 바로 변경이 되어 뒀습니다만 바꿔야 한다면 메인에서 바로 수정 하겠습니다.
- 아아 이제보니 홈버튼이랑 공간대여랑 이미지 비슷하네요 변경할게요
```

## ✅ CheckList

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expired spaces auto-hide hourly.
  - Soft-delete: spaces/reservations can be hidden; lists now show only visible items.
  - Providers can delete rejected/cancelled reservations from My Page (server-confirmed).
  - Inline editing for user info (name, nickname, phone) on My Page.

- Style
  - Updated theme color and refreshed UI: cards, buttons, badges, and icons.
  - Space list redesigned with improved layout, hover effects, and mobile responsiveness.
  - Image fallback added for broken thumbnails.
  - Simplified actions (e.g., removed “문의하기” on space cards); unified button styles and hover states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->