### PR TITLE
chore #POP-156: 팝업 예약버튼 활성화 조건 추가

### DIFF
--- a/src/main/resources/static/css/popup-detail.css
+++ b/src/main/resources/static/css/popup-detail.css
@@ -195,6 +195,21 @@
     background: #5856F0;
 }
 
+.reservation-btn.ended,
+.reservation-btn:disabled {
+    background: #9ca3af !important;
+    color: #f3f4f6 !important;
+    cursor: not-allowed !important;
+    opacity: 0.7;
+}
+
+.reservation-btn.ended:hover,
+.reservation-btn:disabled:hover {
+    background: #9ca3af !important;
+    color: #f3f4f6 !important;
+}
+
+
 /* 위치 섹션 */
 .location-section {
     padding: 20px;

--- a/src/main/resources/static/css/popup-detail.css
+++ b/src/main/resources/static/css/popup-detail.css
@@ -100,6 +100,10 @@
 /* 일정 정보 스타일 */
 .popup-schedule-simple {
     margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
 }
 
 .schedule-item {
@@ -116,6 +120,10 @@
 .period-text {
     font-weight: 600;
     color: #000000;
+    font-size: 16px;
+    line-height: 1.4;
+    align-items: center;
+    padding-right: 8px;
 }
 
 .days-text {
@@ -127,6 +135,44 @@
     font-weight: 400;
     color: #000000;
 }
+
+/* 상태 배지 */
+.status-badge-inline {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 12px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    white-space: nowrap;
+}
+
+/* 진행중 상태 - 파란색 계열 */
+.status-badge-inline.ongoing {
+    background: linear-gradient(135deg, #dbeafe, #bfdbfe);
+    color: #1e40af;
+    border: 1px solid #93c5fd;
+    box-shadow: 0 1px 3px rgba(30, 64, 175, 0.1);
+}
+
+/* 오픈예정 상태 - 보라색 계열 */
+.status-badge-inline.planned {
+    background: linear-gradient(135deg, #ede9fe, #ddd6fe);
+    color: #7c3aed;
+    border: 1px solid #c4b5fd;
+    box-shadow: 0 1px 3px rgba(124, 58, 237, 0.1);
+}
+
+/* 종료 상태 - 회색 계열 */
+.status-badge-inline.ended {
+    background: linear-gradient(135deg, #f3f4f6, #e5e7eb);
+    color: #6b7280;
+    border: 1px solid #d1d5db;
+    box-shadow: 0 1px 3px rgba(107, 114, 128, 0.1);
+}
+
 
 /* 상세 운영시간 스타일 */
 .operating-hours-title {

--- a/src/main/resources/static/css/popup-detail.css
+++ b/src/main/resources/static/css/popup-detail.css
@@ -122,7 +122,6 @@
     color: #000000;
     font-size: 16px;
     line-height: 1.4;
-    align-items: center;
     padding-right: 8px;
 }
 
@@ -242,19 +241,23 @@
 }
 
 .reservation-btn.ended,
-.reservation-btn:disabled {
-    background: #9ca3af !important;
-    color: #f3f4f6 !important;
-    cursor: not-allowed !important;
+.reservation-btn:disabled,
+.reservation-btn[aria-disabled="true"],
+.reservation-btn.disabled {
+    background: #9ca3af;
+    color: #f3f4f6;
+    cursor: not-allowed;
+    pointer-events: none;
     opacity: 0.7;
 }
 
 .reservation-btn.ended:hover,
-.reservation-btn:disabled:hover {
-    background: #9ca3af !important;
-    color: #f3f4f6 !important;
+.reservation-btn:disabled:hover,
+.reservation-btn[aria-disabled="true"]:hover,
+.reservation-btn.disabled:hover {
+    background: #9ca3af;
+    color: #f3f4f6;
 }
-
 
 /* 위치 섹션 */
 .location-section {

--- a/src/main/resources/static/js/popup-detail.js
+++ b/src/main/resources/static/js/popup-detail.js
@@ -214,10 +214,11 @@ class PopupDetailManager {
     renderScheduleInfo() {
         // 기간 표시
         const periodEl = document.getElementById('popup-period');
-        if (periodEl) {
-            // periodText가 있으면 사용, 없으면 직접 생성
+        if (periodEl && this.popupData) {
+            // 기간 텍스트 생성
+            let periodText;
             if (this.popupData.periodText) {
-                periodEl.textContent = this.popupData.periodText;
+                periodText = this.popupData.periodText;
             } else {
                 const startDate = new Date(this.popupData.startDate).toLocaleDateString('ko-KR', {
                     year: 'numeric',
@@ -231,9 +232,47 @@ class PopupDetailManager {
                     day: '2-digit'
                 }).replace(/\. /g, '.').replace(/\.$/, '');
 
-                periodEl.textContent = `${startDate} ~ ${endDate}`;
+                periodText = `${startDate} - ${endDate}`;
             }
+
+            // 상태 배지 생성
+            const statusBadge = this.createInlineStatusBadge(this.popupData.status);
+
+            // 기간과 상태 배지를 함께 표시
+            periodEl.innerHTML = `
+            <span class="period-text">${periodText}</span>
+            ${statusBadge}
+        `;
         }
+    }
+
+    // 인라인 상태 배지 생성 메서드
+    createInlineStatusBadge(status) {
+        const statusInfo = this.getStatusInfo(status);
+        return `<span class="status-badge-inline ${statusInfo.className}">${statusInfo.text}</span>`;
+    }
+
+    // 상태 정보 반환 메서드
+    getStatusInfo(status) {
+        const statusMap = {
+            'PLANNED': {
+                text: '오픈예정',
+                className: 'planned'
+            },
+            'ONGOING': {
+                text: '진행중',
+                className: 'ongoing'
+            },
+            'ENDED': {
+                text: '종료',
+                className: 'ended'
+            }
+        };
+
+        return statusMap[status] || {
+            text: status,
+            className: 'ongoing'
+        };
     }
 
     // 태그와 상태 표시 렌더링
@@ -241,12 +280,6 @@ class PopupDetailManager {
         const tagsEl = document.getElementById('popup-tags');
         if (tagsEl) {
             tagsEl.innerHTML = '';
-
-            // 상태 태그 추가
-            if (this.popupData.status) {
-                const statusTag = this.createStatusTag(this.popupData.status);
-                tagsEl.appendChild(statusTag);
-            }
 
             // 기존 태그들 추가
             if (this.popupData.tags && this.popupData.tags.length > 0) {
@@ -259,14 +292,6 @@ class PopupDetailManager {
                 });
             }
         }
-    }
-
-    // 상태 태그 생성 메서드
-    createStatusTag(status) {
-        const tag = document.createElement('span');
-        tag.className = `status-tag status-${status.toLowerCase()}`;
-        tag.textContent = this.getStatusText(status);
-        return tag;
     }
 
     // 운영시간 렌더링


### PR DESCRIPTION
## 📌 Summary
- resolve: #162 
- Related Jira: POP-156

## ✨ Description
<!-- 변경 사항 요약 -->
### 상세페이지 예약 버튼에 활성화 조건을 추가했습니다.
- 진행중인 팝업인 경우 기존과 동일하게 예약하기 버튼이 활성화 되어있습니다.
- 오픈 예정 팝업인 경우 "사전예약하기" 라고 문구가 바뀌게 되며, 버튼은 활성화 되어 있습니다.
- 종료된 팝업인 경우 "종료된 팝업" 이라고 문구가 바뀌게 되며, 버튼이 비활성화 되어 회색으로 변경되었습니다.

## 📸 Screenshot
<!-- UI 변화가 없다면 지워주세요 -->
|기능|스크린샷|
|:--:|:--:|
|진행중|<img src="https://github.com/user-attachments/assets/4ee023cd-08e7-4ec6-bcbb-9ae5faab1301" width="500" />|
|오픈예정|<img src="https://github.com/user-attachments/assets/da0c6582-1c6e-4768-97c1-58e2db756892" width="500" />|
|종료|<img src="https://github.com/user-attachments/assets/e3eb6a34-5d2f-4886-9f37-3bbf791c5519" width="500" />|


## 🗒️ Review Point
```
추가 수정 사항 생기면 공유해 주세요 :)
```

## ✅ CheckList
- [x] 상태 체크
- [x] 디자인 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline status badges (Planned/Ongoing/Ended) displayed with schedule.
  * Reservation button updates dynamically with status, disabled states, and contextual labels.
  * Bookmark button visuals and interactions updated.
  * Copy address action with immediate feedback.
  * Write-review flow with auth handling and “Load more reviews” pagination.
  * Improved loading/content states and user toasts.

* **Style**
  * New badge designs (gradients, responsive tweaks) and refined spacing/colors.
  * Disabled/ended reservation buttons keep subdued hover/disabled visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->