### PR TITLE
fix #POP-170: 강제 로그인 리다이렉트 수정

### DIFF
--- a/src/main/java/com/snow/popin/global/jwt/JwtFilter.java
+++ b/src/main/java/com/snow/popin/global/jwt/JwtFilter.java
@@ -30,7 +30,6 @@ public class JwtFilter extends OncePerRequestFilter {
     private final JwtTokenResolver jwtTokenResolver;
     private final ApplicationContext applicationContext;
 
-    // UserDetailsService를 지연 로딩으로 가져오기
     private UserDetailsService getUserDetailsService() {
         return applicationContext.getBean(UserDetailsService.class);
     }
@@ -41,96 +40,111 @@ public class JwtFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
 
         String requestURI = req.getRequestURI();
-        log.debug("JWT 필터 처리 시작 : {}", requestURI);
+        log.debug("🔍 JWT 필터 처리 시작 : {}", requestURI);
 
-        try{
+        try {
             String token = jwtTokenResolver.resolve(req);
 
-            if (StringUtils.hasText(token) && jwtUtil.validateToken(token)){
+            if (StringUtils.hasText(token)) {
+                log.debug("토큰 발견 : {}", token.substring(0, Math.min(20, token.length())) + "...");
 
-                log.debug("✅ 토큰 유효함");
+                if (jwtUtil.validateToken(token)) {
+                    log.debug("✅ 토큰 유효함");
 
-                String email = jwtUtil.getEmail(token);
+                    String email = jwtUtil.getEmail(token);
 
-                if (StringUtils.hasText(email)){
-                    log.debug("토큰에서 이메일 추출 : {}", email);
+                    if (StringUtils.hasText(email)) {
+                        log.debug("토큰에서 이메일 추출 : {}", email);
 
-                    // 이미 인증된 경우 스킵
-                    if (SecurityContextHolder.getContext().getAuthentication() == null){
-                        try{
+                        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+                            try {
+                                UserDetails userDetails = getUserDetailsService().loadUserByUsername(email);
+                                log.debug("사용자 정보 로드 완료 : {}", userDetails.getUsername());
 
-                            UserDetails userDetails = getUserDetailsService().loadUserByUsername(email);
-                            log.debug("사용자 정보 로드 완료 : {}", userDetails.getUsername());
+                                UsernamePasswordAuthenticationToken authenticationToken =
+                                        new UsernamePasswordAuthenticationToken(
+                                                userDetails, null, userDetails.getAuthorities()
+                                        );
 
-                            UsernamePasswordAuthenticationToken authenticationToken =
-                                    new UsernamePasswordAuthenticationToken(
-                                            userDetails, null, userDetails.getAuthorities()
-                                    );
+                                authenticationToken.setDetails(
+                                        new WebAuthenticationDetailsSource().buildDetails(req)
+                                );
 
-                            authenticationToken.setDetails(
-                                    new WebAuthenticationDetailsSource().buildDetails(req)
-                            );
+                                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                                log.debug("✅ 사용자 인증 설정 완료 : {}", email);
 
-                            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-                            log.debug("사용자 인증 설정 완료 : {}",email);
-
-                        } catch (Exception e){
-
-                            log.error("❌ 사용자 정보 로드 실패 : {}", e.getMessage());
-                            SecurityContextHolder.clearContext();
-                            sendErrorResponse(res, ErrorCode.USER_NOT_FOUND);
-                            return;
-
+                            } catch (Exception e) {
+                                log.warn("⚠️ 사용자 정보 로드 실패 (공개 페이지면 무시) : {}", e.getMessage());
+                                SecurityContextHolder.clearContext();
+                            }
                         }
                     }
                 } else {
-                    log.debug("❌ 유효한 토큰을 찾을 수 없습니다.");
+                    log.debug("⚠️ 토큰 유효하지 않음 (공개 페이지면 무시)");
                 }
+            } else {
+                log.debug("토큰 없음 (공개 페이지 접근 가능)");
             }
 
+            // 항상 다음 필터로 진행
             filterChain.doFilter(req, res);
 
-        } catch (Exception e){
-            log.error("❌ 필터에서 예외 발생: {}", e.getMessage());
+        } catch (Exception e) {
+            log.error("❌ 필터에서 예외 발생: {} - {}", requestURI, e.getMessage(), e);
             SecurityContextHolder.clearContext();
-            // 클라이언트에게는 표준 401 Unauthorized 에러를 반환
-            sendErrorResponse(res, ErrorCode.UNAUTHORIZED);
 
+            // 예외 발생해도 다음 필터로 진행 (SecurityConfig가 판단)
+            filterChain.doFilter(req, res);
         }
-
     }
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest req) {
         String path = req.getRequestURI();
 
-        log.debug("필터 제외 경로 확인 : {}", path);
+        log.debug("🔍 필터 제외 경로 확인 : {}", path);
 
         // 정적 리소스
         if (path.startsWith("/css/") || path.startsWith("/js/") ||
                 path.startsWith("/images/") || path.startsWith("/static/") ||
-                path.equals("/favicon.ico")) {
+                path.startsWith("/uploads/") ||
+                path.equals("/favicon.ico") || path.startsWith("/templates/")) {
+            log.debug("✅ 정적 리소스 - 필터 제외");
             return true;
         }
 
         // 공개 페이지
         if (path.equals("/") || path.equals("/index.html") ||
                 path.equals("/main") || path.equals("/error")) {
+            log.debug("✅ 공개 페이지 - 필터 제외");
+            return true;
+        }
+
+        // 팝업 관련 페이지
+        if (path.startsWith("/popup/") || path.startsWith("/map") ||
+                path.startsWith("/space/") || path.startsWith("/reviews/")) {
+            log.debug("✅ 공개 콘텐츠 페이지 - 필터 제외");
             return true;
         }
 
         // 인증 페이지
         if (path.startsWith("/auth/")) {
+            log.debug("✅ 인증 페이지 - 필터 제외");
             return true;
         }
 
         // 공개 API
         if (path.equals("/api/auth/login") ||
                 path.equals("/api/auth/signup") ||
-                path.equals("/api/auth/check-email")) {
+                path.equals("/api/auth/check-email") ||
+                path.equals("/api/auth/check-nickname") ||
+                path.startsWith("/api/popups") ||
+                (path.startsWith("/api/reviews") && req.getMethod().equals("GET"))) {
+            log.debug("✅ 공개 API - 필터 제외");
             return true;
         }
 
+        log.debug("❌ 보호된 경로 - 필터 적용");
         return false;
     }
 }

--- a/src/main/resources/static/js/auth/loginController.js
+++ b/src/main/resources/static/js/auth/loginController.js
@@ -58,9 +58,20 @@ class LoginController {
         }
 
         if (token && !this.loginApi.isTokenExpired()) {
-            const shouldRedirect = confirm('이미 로그인되어 있습니다. 메인 페이지로 이동하시겠습니까?');
-            if (shouldRedirect) {
-                window.location.href = '/';
+            // redirect 파라미터 확인
+            const urlParams = new URLSearchParams(window.location.search);
+            const redirectUrl = urlParams.get('redirect');
+
+            if (redirectUrl) {
+                // redirect 파라미터가 있으면 자동으로 그 페이지로 이동
+                console.log('이미 로그인됨, 원래 페이지로 이동:', redirectUrl);
+                window.location.href = decodeURIComponent(redirectUrl);
+            } else {
+                // redirect 파라미터가 없으면 확인창 띄우기
+                const shouldRedirect = confirm('이미 로그인되어 있습니다. 메인 페이지로 이동하시겠습니까?');
+                if (shouldRedirect) {
+                    window.location.href = '/';
+                }
             }
         } else if (token) {
             // 만료된 토큰 제거

--- a/src/main/resources/static/js/auth/loginController.js
+++ b/src/main/resources/static/js/auth/loginController.js
@@ -43,7 +43,21 @@ class LoginController {
 
         // URL 파라미터 정리
         if (urlParams.toString()) {
-            window.history.replaceState({}, document.title, window.location.pathname);
+            const redirectParam = urlParams.get('redirect');
+
+            if (redirectParam) {
+                // redirect 파라미터만 남기고 나머지 제거
+                const cleanParams = new URLSearchParams();
+                cleanParams.set('redirect', redirectParam);
+                window.history.replaceState(
+                    {},
+                    document.title,
+                    `${window.location.pathname}?${cleanParams.toString()}`
+                );
+            } else {
+                // redirect가 없으면 모든 파라미터 제거
+                window.history.replaceState({}, document.title, window.location.pathname);
+            }
         }
     }
 

--- a/src/main/resources/static/js/layout.js
+++ b/src/main/resources/static/js/layout.js
@@ -280,6 +280,7 @@ function checkAuthOnPageLoad() {
         '/popup/',
         '/map',
         '/reviews/',
+        '/space',
     ];
 
     // 현재 경로가 공개 페이지인지 확인

--- a/src/main/resources/static/js/layout.js
+++ b/src/main/resources/static/js/layout.js
@@ -1,5 +1,21 @@
 // 공통 레이아웃 스크립트
 
+// 페이지 로드 시 토큰을 쿠키에 동기화
+(function syncTokenToCookie() {
+    const token = localStorage.getItem('authToken') ||
+        localStorage.getItem('accessToken') ||
+        sessionStorage.getItem('authToken') ||
+        sessionStorage.getItem('accessToken');
+
+    if (token) {
+        // 쿠키에 토큰이 없으면 동기화
+        if (!document.cookie.includes('jwtToken=')) {
+            document.cookie = `jwtToken=${token}; path=/; max-age=86400; SameSite=Lax`;
+            console.log('✅ 토큰을 쿠키에 동기화했습니다.');
+        }
+    }
+})();
+
 // HTML 컴포넌트 로드 함수
 async function loadComponents() {
     try {
@@ -254,15 +270,35 @@ async function performLogout() {
 
 // === 인증 체크 ===
 function checkAuthOnPageLoad() {
-    // 현재 페이지가 로그인 페이지가 아닌 경우에만 체크
-    if (!window.location.pathname.includes('/auth/')) {
-        const token = apiService.getStoredToken();
-        if (!token || isTokenExpired(token)) {
-            console.log('인증되지 않은 사용자, 로그인 페이지로 리다이렉트');
-            window.location.href = '/auth/login';
-            return false;
-        }
+    const currentPath = window.location.pathname;
+
+    // 공개 페이지는 인증 체크 하지 않음
+    const publicPaths = [
+        '/',
+        '/index.html',
+        '/main',
+        '/popup/',
+        '/map',
+        '/reviews/',
+    ];
+
+    // 현재 경로가 공개 페이지인지 확인
+    const isPublicPage = publicPaths.some(path => currentPath.startsWith(path) || currentPath === path);
+
+    if (isPublicPage) {
+        console.log('공개 페이지 - 인증 체크 건너뜀');
+        return true;
     }
+
+    // 비공개 페이지(마이페이지, 북마크 등)만 토큰 체크
+    const token = apiService.getStoredToken();
+    if (!token || isTokenExpired(token)) {
+        console.log('인증 필요한 페이지 - 로그인 페이지로 리다이렉트');
+        const redirectUrl = encodeURIComponent(currentPath);
+        window.location.href = `/auth/login?redirect=${redirectUrl}`;
+        return false;
+    }
+
     return true;
 }
 
@@ -397,23 +433,29 @@ async function getUserRole() {
 document.addEventListener('DOMContentLoaded', async () => {
     // 인증 체크
     if (checkAuthOnPageLoad()) {
-        setupAutoLogout();
 
-        // 로그인된 사용자면 알림 상태 초기화
-        const userInfo = getUserInfo();
-        if (userInfo?.userId) {
-            try {
-                // 초기 알림 목록 조회 → 뱃지 상태 업데이트
-                const notifications = await apiService.getNotifications();
-                const hasUnread = notifications.some(n => !n.read);
-                updateNotificationBadge(hasUnread);
-            } catch (err) {
-                console.error("초기 알림 조회 실패:", err);
+        // 토큰이 있는 사용자만 자동 로그아웃 설정 및 알림 체크
+        const token = apiService.getStoredToken();
+
+        if (token) {
+            setupAutoLogout();
+
+            // 로그인된 사용자면 알림 상태 초기화
+            const userInfo = getUserInfo();
+            if (userInfo?.userId) {
+                try {
+                    // 초기 알림 목록 조회 → 뱃지 상태 업데이트
+                    const notifications = await apiService.getNotifications();
+                    const hasUnread = notifications.some(n => !n.read);
+                    updateNotificationBadge(hasUnread);
+                } catch (err) {
+                    console.warn("초기 알림 조회 실패 (무시):", err);
+                    // 에러 무시 - 토큰이 만료되었거나 권한이 없을 수 있음
+                }
             }
         }
     }
 });
-
 
 // === 알림 목록 불러오기 ===
 async function showNotifications() {
@@ -421,9 +463,20 @@ async function showNotifications() {
     dropdown.classList.toggle("hidden");
 
     if (!dropdown.classList.contains("hidden")) {
+        const listEl = document.getElementById("notificationList");
+
+        // 로그인 여부 체크
+        const token = apiService.getStoredToken();
+
+        if (!token) {
+            // 로그인 안한 상태 - 로그인 안내 표시
+            listEl.innerHTML = "<li class='no-data'>로그인 후 알림을 확인할 수 있습니다.</li>";
+            updateNotificationBadge(false);
+            return;
+        }
+
         try {
             const notifications = await apiService.getNotifications();
-            const listEl = document.getElementById("notificationList");
             listEl.innerHTML = "";
 
             if (!notifications || notifications.length === 0) {
@@ -443,7 +496,7 @@ async function showNotifications() {
 
         } catch (err) {
             console.error("알림 불러오기 실패:", err);
-            document.getElementById("notificationList").innerHTML =
+            listEl.innerHTML =
                 "<li class='error'>알림을 불러오는 중 오류가 발생했습니다.</li>";
         }
     }

--- a/src/main/resources/static/js/mypage/user/user-bookmarks.js
+++ b/src/main/resources/static/js/mypage/user/user-bookmarks.js
@@ -1,6 +1,4 @@
 document.addEventListener('DOMContentLoaded', async function () {
-    await loadComponents();   // header/footer 로드
-    initializeLayout();
 
     // 로그인 체크
     const token = apiService.getStoredToken();

--- a/src/main/resources/static/js/popup-detail.js
+++ b/src/main/resources/static/js/popup-detail.js
@@ -189,8 +189,9 @@ class PopupDetailManager {
             this.isBookmarked = result.bookmarked || false;
             this.updateBookmarkButton();
         } catch (error) {
-            console.warn('북마크 상태 확인 실패:', error);
+            console.debug('북마크 상태 확인 실패:', error);
             this.isBookmarked = false; // 기본값으로 설정
+            this.updateBookmarkButton();
         }
     }
 
@@ -449,8 +450,15 @@ class PopupDetailManager {
         }
     }
 
-    // 북마크 처리
+// 북마크 처리
     async handleBookmark() {
+        // 로그인 체크
+        const token = apiService.getStoredToken();
+        if (!token) {
+            alert('로그인 후 이용 가능합니다.');
+            return;
+        }
+
         try {
             if (this.isBookmarked) {
                 await apiService.removeBookmark(this.popupId);

--- a/src/main/resources/static/js/popup-detail.js
+++ b/src/main/resources/static/js/popup-detail.js
@@ -203,7 +203,7 @@ class PopupDetailManager {
         if (mainImg) {
             const defaultImage = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAwIiBoZWlnaHQ9IjMwMCIgdmlld0JveD0iMCAwIDYwMCAzMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSI2MDAiIGhlaWdodD0iMzAwIiBmaWxsPSIjNEI1QUU0Ii8+Cjx0ZXh0IHg9IjMwMCIgeT0iMTUwIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSI0OCIgZmlsbD0id2hpdGUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGRvbWluYW50LWJhc2VsaW5lPSJjZW50cmFsIj7wn46qPC90ZXh0Pgo8L3N2Zz4=';
 
-            mainImg.src = this.popupData.thumbnailUrl || defaultImage;
+            mainImg.src = this.popupData.mainImageUrl || defaultImage;
             mainImg.alt = this.popupData.title;
         }
 

--- a/src/main/resources/static/templates/auth/login.html
+++ b/src/main/resources/static/templates/auth/login.html
@@ -64,6 +64,7 @@
 <script src="/js/auth/loginValidator.js"></script>
 <script src="/js/auth/loginUI.js"></script>
 <script src="/js/auth/loginController.js"></script>
+<script src="/js/pages.js"></script>
 
 
 <script>


### PR DESCRIPTION
## 📌 Summary
- resolve: #180 
- Related Jira: POP-170

## ✨ Description
<!-- 변경 사항 요약 -->
### 강제로 로그인 화면으로 이동하는 문제를 해결했습니다.
Spring Security 설정 (SecurityConfig.java)
- 공개 페이지: /, /popup/**, /map, /space/** 등 → 로그인 없이 접근 가능
- 인증 필요 페이지: /mypage/**, /bookmarks/**, /chat/** → 로그인 필수
- 공개 API: GET /api/popups/**, GET /api/spaces/**, GET /api/reviews/** 허용
- 인증 필요 API: POST/PUT/DELETE 요청, /api/bookmarks/**, /api/host/** 등

JwtFilter.java 수정
- 공개 페이지에서 토큰 검증 실패 시 에러 throw만 하고 계속 진행
- shouldNotFilter()에 공개 경로 추가
- 예외 발생해도 필터 체인 계속 진행 (SecurityConfig가 판단)

layout.js 수정
-checkAuthOnPageLoad(): 공개 페이지는 인증 체크 건너뜀
- 알림 API: 토큰 있을 때만 호출
- showNotifications(): 로그인 안 한 상태면 "로그인 후 알림 확인 가능" 표시

loginController.js 수정
- checkExistingToken(): redirect 파라미터가 있으면 자동으로 원래 페이지로 이동
- 로그인 성공 시 redirect 파라미터 확인 후 해당 페이지로 이동

api.js 수정
- storeToken(): localStorage + 쿠키에도 토큰 저장 (서버가 읽을 수 있도록)
- removeToken(): 쿠키에서도 토큰 삭제


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - More granular access control with public GET endpoints, protected actions, and admin-only areas.
  - Login redirects now preserve the original destination via a redirect parameter.
  - Automatic token-to-cookie sync and smarter auth checks on page load.

- Bug Fixes
  - Silent API checks to avoid unnecessary error-page redirects (e.g., bookmark status).
  - Login auto-redirect when already authenticated.
  - Bookmark actions require login and fail gracefully when unauthenticated.
  - Notifications and layout init respect login state.

- Chores
  - Expanded and clarified authentication logging and exclusion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->